### PR TITLE
fix: open editor when adding a license

### DIFF
--- a/packages/public/server/package.json
+++ b/packages/public/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serlo/athene2",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "license": "Apache-2.0",
   "author": "Serlo Education e.V.",
   "scripts": {

--- a/packages/public/server/src/module/License/src/License/Controller/LicenseController.php
+++ b/packages/public/server/src/module/License/src/License/Controller/LicenseController.php
@@ -101,6 +101,7 @@ class LicenseController extends AbstractActionController
         } else {
             $this->referer()->store();
         }
+        $this->layout('athene2-editor');
 
         return $view;
     }


### PR DESCRIPTION
At the moment the page `/license/add` does look like this:
![grafik](https://user-images.githubusercontent.com/11499926/61146043-4db3d380-a4d9-11e9-8dbc-84ccdae2eac6.png)
"Inhalt" is an editor content, which is problematic because you can't enter it in that text-area :D

`/license/update/:id` does this correctly already.