### PR TITLE
Added implementation for Serlo-French (fr.serlo.org)

### DIFF
--- a/packages/public/cloudflare-workers/src/index.ts
+++ b/packages/public/cloudflare-workers/src/index.ts
@@ -119,7 +119,7 @@ async function serloOrgProxy(request: Request) {
     return res
   }
 
-  const match = request.url.match(/^https:\/\/(de|en|es|hi|ta)\.serlo\.org/)
+  const match = request.url.match(/^https:\/\/(de|en|es|hi|ta|fr)\.serlo\.org/)
   if (!match) return null
 
   const { backend, createCookie } = chooseBackend()

--- a/packages/public/server/docker/php/Dockerfile
+++ b/packages/public/server/docker/php/Dockerfile
@@ -9,6 +9,7 @@ RUN sed -ie 's/# en_GB.UTF-8 UTF-8/en_GB.UTF-8 UTF-8/g' /etc/locale.gen
 RUN sed -ie 's/# de_DE.UTF-8 UTF-8/de_DE.UTF-8 UTF-8/g' /etc/locale.gen
 RUN sed -ie 's/# hi_IN UTF-8/hi_IN UTF-8/g' /etc/locale.gen
 RUN sed -ie 's/# ta_IN UTF-8/ta_IN UTF-8/g' /etc/locale.gen
+RUN sed -ie 's/# fr_FR UTF-8/fr_FR UTF-8/g' /etc/locale.gen
 RUN sed -ie 's/# es_ES.UTF-8 UTF-8/es_ES.UTF-8 UTF-8/g' /etc/locale.gen
 RUN DEBIAN_FRONTEND=noninteractive dpkg-reconfigure locales
 WORKDIR /usr/local/apache2/htdocs

--- a/packages/public/server/docker/php/Dockerfile
+++ b/packages/public/server/docker/php/Dockerfile
@@ -9,7 +9,7 @@ RUN sed -ie 's/# en_GB.UTF-8 UTF-8/en_GB.UTF-8 UTF-8/g' /etc/locale.gen
 RUN sed -ie 's/# de_DE.UTF-8 UTF-8/de_DE.UTF-8 UTF-8/g' /etc/locale.gen
 RUN sed -ie 's/# hi_IN UTF-8/hi_IN UTF-8/g' /etc/locale.gen
 RUN sed -ie 's/# ta_IN UTF-8/ta_IN UTF-8/g' /etc/locale.gen
-RUN sed -ie 's/# fr_FR UTF-8/fr_FR UTF-8/g' /etc/locale.gen
+RUN sed -ie 's/# fr_FR.UTF-8 UTF-8/fr_FR.UTF-8 UTF-8/g' /etc/locale.gen
 RUN sed -ie 's/# es_ES.UTF-8 UTF-8/es_ES.UTF-8 UTF-8/g' /etc/locale.gen
 RUN DEBIAN_FRONTEND=noninteractive dpkg-reconfigure locales
 WORKDIR /usr/local/apache2/htdocs

--- a/packages/public/server/package.json
+++ b/packages/public/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serlo/athene2",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "license": "Apache-2.0",
   "author": "Serlo Education e.V.",
   "scripts": {

--- a/packages/public/server/src/config/autoload/global.php
+++ b/packages/public/server/src/config/autoload/global.php
@@ -61,6 +61,13 @@ return [
                 'logo' => '<span class="serlo-logo">V</span>',
                 'head_title' => 'aprende con Serlo!',
             ],
+            'french' => [ 
+                'name' => '<div class="serlo-brand">Serlo</div>', 
+                'slogan' => 'La plateforme d\'apprentissage libre', 
+                'description' => 'Serlo est un service libre qui offre des ressources éducatives auxquelles chacun(e) peut contribuer.', 
+                'logo' => '<span class="serlo-logo">V</span>', 
+                'head_title' => 'apprendre avec Serlo!', 
+            ], 
             'hindi' => [
                 'name' => '<div class="serlo-brand">सेर्लो</div>',
                 'slogan' => 'ओपन लर्निंग प्लेटफॉर्म',

--- a/packages/public/server/src/config/autoload/global.php
+++ b/packages/public/server/src/config/autoload/global.php
@@ -61,13 +61,13 @@ return [
                 'logo' => '<span class="serlo-logo">V</span>',
                 'head_title' => 'aprende con Serlo!',
             ],
-            'french' => [ 
-                'name' => '<div class="serlo-brand">Serlo</div>', 
-                'slogan' => 'La plateforme d\'apprentissage libre', 
-                'description' => 'Serlo est un service libre qui offre des ressources éducatives auxquelles chacun(e) peut contribuer.', 
-                'logo' => '<span class="serlo-logo">V</span>', 
-                'head_title' => 'apprendre avec Serlo!', 
-            ], 
+            'french' => [
+                'name' => '<div class="serlo-brand">Serlo</div>',
+                'slogan' => 'La plateforme d\'apprentissage libre',
+                'description' => 'Serlo est un service libre qui offre des ressources éducatives auxquelles chacun(e) peut contribuer.',
+                'logo' => '<span class="serlo-logo">V</span>',
+                'head_title' => 'apprendre avec Serlo!',
+            ],
             'hindi' => [
                 'name' => '<div class="serlo-brand">सेर्लो</div>',
                 'slogan' => 'ओपन लर्निंग प्लेटफॉर्म',

--- a/packages/public/server/src/lang/routes/fr.php
+++ b/packages/public/server/src/lang/routes/fr.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * This file is part of Serlo.org.
+ *
+ * Copyright (c) 2013-2019 Serlo Education e.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @copyright Copyright (c) 2013-2019 Serlo Education e.V.
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://github.com/serlo-org/serlo.org for the canonical source repository
+ */
+return [
+    'subject' => 'subject',
+    'topic'   => 'topic',
+];

--- a/packages/public/server/src/module/Subject/config/instances.config.php
+++ b/packages/public/server/src/module/Subject/config/instances.config.php
@@ -213,6 +213,53 @@ return [
                     ],
                 ],
             ],
+            'french' => [
+                'mathématiques' => [
+                    'allowed_taxonomies' => [
+                        'topic',
+                        'locale',
+                    ],
+                    'allowed_entities'   => [
+                        'article',
+                        'text-exercise',
+                        'video',
+                        'course',
+                        'text-exercise-group',
+                        'math-puzzle',
+                        'applet',
+                    ],
+                ],
+                'community' => [
+                    'allowed_taxonomies' => [
+                        'topic',
+                        'locale',
+                    ],
+                    'allowed_entities'   => [
+                        'article',
+                        'text-exercise',
+                        'video',
+                        'course',
+                        'text-exercise-group',
+                        'math-puzzle',
+                        'applet',
+                    ],
+                ],
+                'nouvelles matières' => [
+                    'allowed_taxonomies' => [
+                        'topic',
+                        'locale',
+                    ],
+                    'allowed_entities'   => [
+                        'article',
+                        'text-exercise',
+                        'video',
+                        'course',
+                        'text-exercise-group',
+                        'math-puzzle',
+                        'applet',
+                    ],
+                ],
+            ],
             'english' => [
                 'math' => [
                     'allowed_taxonomies' => [


### PR DESCRIPTION
I added following  https://github.com/serlo/serlo.org/issues/8 the implementation for Serlo-French. I only missed the folder-creation in step 2 (because I have no export-access to crowdin) and in Step 6 the static-assets (serlo.org/public/static-assets). 

Language-code for french: fr_FR
Terms for the image (on the starting-page) in the static-assets: 

democratically structured | structure démocratique
non-profit | non-lucratif
free of charge | gratuit
ad-free | sans publicité
openly licensed | licence libre
transparent | transparent

