### PR TITLE
Fix: Convert sc-mc content and feedback to text not rows

### DIFF
--- a/packages/private/edtr-io/src/deserialize.ts
+++ b/packages/private/edtr-io/src/deserialize.ts
@@ -335,12 +335,20 @@ export function deserialize({
               ...(isSingleChoice && singleChoiceRightAnswer
                 ? [
                     {
-                      id: convert(
-                        deserializeEditorState(singleChoiceRightAnswer.content)
+                      id: extractChildFromRows(
+                        convert(
+                          deserializeEditorState(
+                            singleChoiceRightAnswer.content
+                          )
+                        )
                       ),
                       isCorrect: true,
-                      feedback: convert(
-                        deserializeEditorState(singleChoiceRightAnswer.feedback)
+                      feedback: extractChildFromRows(
+                        convert(
+                          deserializeEditorState(
+                            singleChoiceRightAnswer.feedback
+                          )
+                        )
                       ),
                       hasFeedback: !!singleChoiceRightAnswer.feedback
                     }
@@ -353,10 +361,12 @@ export function deserialize({
                     })
                     .map(answer => {
                       return {
-                        id: convert(deserializeEditorState(answer.content)),
+                        id: extractChildFromRows(
+                          convert(deserializeEditorState(answer.content))
+                        ),
                         isCorrect: false,
-                        feedback: convert(
-                          deserializeEditorState(answer.feedback)
+                        feedback: extractChildFromRows(
+                          convert(deserializeEditorState(answer.feedback))
                         ),
                         hasFeedback: !!answer.feedback
                       }
@@ -369,11 +379,12 @@ export function deserialize({
                     })
                     .map(answer => {
                       return {
-                        id: convert(deserializeEditorState(answer.content)),
+                        id: extractChildFromRows(
+                          convert(deserializeEditorState(answer.content))
+                        ),
                         isCorrect: true,
                         feedback: {
-                          plugin: 'rows',
-                          state: [{ plugin: 'text' }]
+                          plugin: 'text'
                         },
                         hasFeedback: false
                       }
@@ -386,10 +397,12 @@ export function deserialize({
                     })
                     .map(answer => {
                       return {
-                        id: convert(deserializeEditorState(answer.content)),
+                        id: extractChildFromRows(
+                          convert(deserializeEditorState(answer.content))
+                        ),
                         isCorrect: false,
-                        feedback: convert(
-                          deserializeEditorState(answer.feedback)
+                        feedback: extractChildFromRows(
+                          convert(deserializeEditorState(answer.feedback))
                         ),
                         hasFeedback: !!answer.feedback
                       }
@@ -400,6 +413,10 @@ export function deserialize({
         }
       }
     }
+  }
+
+  function extractChildFromRows(plugin: RowsPlugin) {
+    return plugin.state.length ? plugin.state[0] : { plugin: 'text' }
   }
 
   function deserializeTextExerciseGroup(

--- a/packages/private/legacy-editor-to-editor/src/index.ts
+++ b/packages/private/legacy-editor-to-editor/src/index.ts
@@ -21,9 +21,15 @@
  */
 import split from './legacyToSplish/split'
 import transform from './legacyToSplish/transform'
-import { Edtr, Legacy, Splish, isSplish, convertRow } from './splishToEdtr'
+import {
+  Legacy,
+  Splish,
+  RowsPlugin,
+  isSplish,
+  convertRow
+} from './splishToEdtr'
 
-export function convert(content: Legacy | Splish): Edtr {
+export function convert(content: Legacy | Splish): RowsPlugin {
   if (!content) return { plugin: 'rows', state: [] }
   const splish = isSplish(content)
     ? content
@@ -39,7 +45,7 @@ export function convertLegacyToSplish(content: Legacy, id: string): Splish {
   }
 }
 
-export function convertSplishToEdtrIO(content: Splish): Edtr {
+export function convertSplishToEdtrIO(content: Splish): RowsPlugin {
   return {
     plugin: 'rows',
     state: convertRow(content)


### PR DESCRIPTION
This fixes #39 taking the first row of the row plugin and use it for content or feedback of the single-/multiple choice plugin

**NOTE**: Might run into problems on some old contents, e.g. when the feedback uses text and images or multiple text blocks.

I also added the `email` and `email_sent` columns to the database (cf. #38)