### PR TITLE
Fix: convert tables correctly

### DIFF
--- a/packages/private/legacy-editor-to-editor/src/splishToEdtr/convertPlugins.ts
+++ b/packages/private/legacy-editor-to-editor/src/splishToEdtr/convertPlugins.ts
@@ -27,10 +27,11 @@ import {
   SplishGeogebraState,
   SplishInjectionState,
   SplishSpoilerState,
+  SplishTableState,
   SplishTextState
 } from '../legacyToSplish/createPlugin'
 import { convertOldSlate, htmlToSlate } from './convertSlate'
-import { ContentCell, Edtr, LayoutPlugin, OtherPlugin } from './types'
+import { ContentCell, OtherPlugin } from './types'
 import { convertSplishToEdtrIO } from '..'
 
 export function convertPlugin(cell: ContentCell): OtherPlugin {
@@ -76,9 +77,10 @@ export function convertPlugin(cell: ContentCell): OtherPlugin {
         }
       }
     case Plugin.Table:
+      const tableState = state as SplishTableState
       return {
         plugin: 'table',
-        state
+        state: tableState.src
       }
     case Plugin.Geogebra:
       const geogebraState = state as SplishGeogebraState


### PR DESCRIPTION
Splish plugin state had a different structure than the new plugin, so the table plugin received an object instead of string.