### PR TITLE
fix: show solutions in new editor exercises

### DIFF
--- a/packages/public/server/package.json
+++ b/packages/public/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serlo/serlo-org-server",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "license": "Apache-2.0",
   "author": "Serlo Education e.V.",
   "scripts": {

--- a/packages/public/server/src/module/Ui/templates/entity/view/partials/text-exercise.twig
+++ b/packages/public/server/src/module/Ui/templates/entity/view/partials/text-exercise.twig
@@ -170,7 +170,7 @@
             <a class="collapse-hide-label">{% trans %} Hide hint {% endtrans %}<span class="dropup"><span class="caret"></span></span></a>
         </div>
     {% endif %}
-    {% if isLegacyFormat(revision.get('content')) and singleChoices|length == 0 and multipleChoices|length == 0 and not inputChallenge and showSolution %}
+    {% if not isLegacyFormat(revision.get('content')) or (singleChoices|length == 0 and multipleChoices|length == 0 and not inputChallenge and showSolution) %}
         <div class="solution collapsed" data-toggle="collapse"
              data-target="#solution-{{ solution.getId() }}">
             <a class="collapse-show-label">{% trans %} Show solution {% endtrans %}<span class="caret"></span></a>


### PR DESCRIPTION
fix issue introduced in #43 where solutions of sc-mc-exercises by the new editor are not visible 