### PR TITLE
Various fixes

### DIFF
--- a/packages/private/edtr-io/src/editor.tsx
+++ b/packages/private/edtr-io/src/editor.tsx
@@ -113,7 +113,7 @@ export function Editor(props: EditorProps) {
     const isExercise = [
       'grouped-text-exercise',
       'text-exercise',
-      'grouped-text-exercise'
+      'text-exercise-group'
     ].includes(props.type)
     return [
       {

--- a/packages/private/edtr-io/src/plugins/types/course-page.tsx
+++ b/packages/private/edtr-io/src/plugins/types/course-page.tsx
@@ -51,6 +51,11 @@ function CoursePageTypeEditor(
 ) {
   const { title, icon, content } = props.state
 
+  React.useEffect(() => {
+    if (!['explanation', 'play', 'question'].includes(icon.value)) {
+      icon.set('explanation')
+    }
+  }, [icon.value])
   return (
     <article>
       <Settings>

--- a/packages/private/edtr-io/src/plugins/types/course.tsx
+++ b/packages/private/edtr-io/src/plugins/types/course.tsx
@@ -34,7 +34,8 @@ import {
   entity,
   Controls,
   serializedChild,
-  HeaderInput
+  HeaderInput,
+  OptionalChild
 } from './common'
 import { Settings } from './helpers/settings'
 
@@ -78,12 +79,15 @@ function CourseTypeEditor(
           <span itemProp="name">{title.value}</span>
         )}
       </h1>
-      {children.map(child => {
+      {children.map((child, index) => {
         return (
-          <React.Fragment key={child.id}>
-            <hr />
-            {child.render({ skipControls: true })}
-          </React.Fragment>
+          <OptionalChild
+            state={child}
+            key={child.id}
+            onRemove={() => {
+              children.remove(index)
+            }}
+          />
         )
       })}
       <hr />

--- a/packages/private/edtr-io/src/plugins/types/text-exercise-group.tsx
+++ b/packages/private/edtr-io/src/plugins/types/text-exercise-group.tsx
@@ -28,7 +28,13 @@ import {
 } from '@edtr-io/plugin'
 import * as React from 'react'
 
-import { editorContent, entity, Controls, serializedChild } from './common'
+import {
+  editorContent,
+  entity,
+  Controls,
+  serializedChild,
+  OptionalChild
+} from './common'
 
 export const textExerciseGroupTypeState = object({
   ...entity,
@@ -58,7 +64,12 @@ function TextExerciseGroupTypeEditor(
               <em>{String.fromCharCode(97 + index)})</em>
             </div>
             <div className="col-sm-11 col-xs-12">
-              {child.render({ skipControls: true })}
+              <OptionalChild
+                state={child}
+                onRemove={() => {
+                  children.remove(index)
+                }}
+              />
             </div>
           </section>
         )

--- a/packages/private/edtr-io/src/plugins/types/text-exercise.tsx
+++ b/packages/private/edtr-io/src/plugins/types/text-exercise.tsx
@@ -30,7 +30,8 @@ import {
   editorContent,
   entity,
   Controls,
-  optionalSerializedChild
+  optionalSerializedChild,
+  OptionalChild
 } from './common'
 import { AddButton } from '@edtr-io/editor-ui'
 
@@ -63,7 +64,12 @@ export function TextExerciseTypeEditor(
     <article className="text-exercise">
       {content.render()}
       {textHint.id ? (
-        textHint.render({ skipControls: true })
+        <OptionalChild
+          state={textHint}
+          onRemove={() => {
+            textHint.remove()
+          }}
+        />
       ) : (
         <AddButton
           onClick={() => {
@@ -74,7 +80,12 @@ export function TextExerciseTypeEditor(
         </AddButton>
       )}
       {textSolution.id ? (
-        textSolution.render({ skipControls: true })
+        <OptionalChild
+          state={textSolution}
+          onRemove={() => {
+            textSolution.remove()
+          }}
+        />
       ) : (
         <AddButton
           onClick={() => {

--- a/packages/public/client/package.json
+++ b/packages/public/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serlo/serlo-org-client",
-  "version": "2.0.17",
+  "version": "2.0.18",
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "cross-env NODE_ENV=production webpack --config webpack.prod.config --output-public-path=https://packages.serlo.org/serlo-org-client@$npm_package_version/",


### PR DESCRIPTION
- enable exercise specific plugins in text exercise group
- handle invalid course page icons (legacy course pages might have those)
- newly added childs now also are removable.