### PR TITLE
Fix: Rerender new editor content in legacy injections

### DIFF
--- a/packages/public/client/package.json
+++ b/packages/public/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serlo/serlo-org-client",
-  "version": "2.0.20",
+  "version": "2.0.21",
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "cross-env NODE_ENV=production webpack --config webpack.prod.config --output-public-path=https://packages.serlo.org/serlo-org-client@$npm_package_version/",

--- a/packages/public/client/src/editor/content/index.ts
+++ b/packages/public/client/src/editor/content/index.ts
@@ -21,8 +21,11 @@
  */
 import $ from 'jquery'
 
-export const initContent = () => {
-  const $elements = $('.edtr-io[data-edit-type="edtr-io"][data-raw-content]')
+export const initContent = ($context: JQuery<HTMLElement>) => {
+  const $elements = $(
+    '.edtr-io[data-edit-type="edtr-io"][data-raw-content]',
+    $context
+  )
 
   if ($elements.length === 0) {
     return

--- a/packages/public/client/src/main/index.js
+++ b/packages/public/client/src/main/index.js
@@ -157,7 +157,6 @@ const init = $context => {
   setLanguage()
   initChangeDimensionEvents()
   initContentApi()
-  initContent()
   initConsentBanner()
 
   // create an system notification whenever Common.genericError is called
@@ -170,6 +169,7 @@ const init = $context => {
   }
 
   Content.add($context => {
+    initContent($context)
     $('.sortable', $context).SortableList()
     $('.timeago', $context).TimeAgo()
     $('.dialog', $context).SerloModals()

--- a/packages/public/client/src/main/index.js
+++ b/packages/public/client/src/main/index.js
@@ -189,7 +189,7 @@ const init = $context => {
     $('.math-puzzle', $context).MathPuzzle()
     $('form:has(button.g-recaptcha)').ReCaptcha()
 
-    const $editor = $('#editor', $context)
+    const $editor = $('#editor[data-state][data-type]', $context)
     if ($editor.length > 0) {
       initEntityEditor(
         {


### PR DESCRIPTION
* avoid unintentionally loading editor on #editor elements
* rerender content with new editor after injections (fixes #67)