### PR TITLE
Filter non letter characters from alias

### DIFF
--- a/packages/public/server/src/module/Common/src/Common/Filter/Slugify.php
+++ b/packages/public/server/src/module/Common/src/Common/Filter/Slugify.php
@@ -32,8 +32,11 @@ class Slugify implements FilterInterface
      */
     protected static function slugify($text)
     {
-        $text = trim($text, " ");
         $text = preg_replace("~ +~u", '-', $text);
+        // replace non letter or digits
+        $text = preg_replace('~[^\\pL\\pM\d-]+~u', '', $text);
+        // trim
+        $text = trim($text, '-');
         $text = strtolower($text);
         if (empty($text)) {
             return false;


### PR DESCRIPTION
Filter non letter characters (respecting unicode) from alias, because e.g. this looks weird: https://de.serlo.org/mathe/geometrie/dreiecke,-vierecke,-kreise-andere-ebene-figuren/kreise-kreisteile/berechnungen-kreis
