### PR TITLE
improve logging of failed server side renderings

### DIFF
--- a/packages/public/editor-renderer/package.json
+++ b/packages/public/editor-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serlo/serlo-org-editor-renderer",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "main": "dist/index.js",
   "scripts": {
     "prebuild": "rimraf dist",

--- a/packages/public/editor-renderer/src/index.ts
+++ b/packages/public/editor-renderer/src/index.ts
@@ -33,7 +33,6 @@ app.use(bodyParser.json())
 app.post('/', (req: { body: { state: string } }, res) => {
   render(req.body.state)
     .then(html => {
-      console.log(html)
       console.log('request successful')
       res.status(200).send({ html })
     })

--- a/packages/public/editor-renderer/src/render.tsx
+++ b/packages/public/editor-renderer/src/render.tsx
@@ -48,6 +48,7 @@ export async function render(input: string): Promise<string> {
   try {
     return wrapOutput(coreRender({ plugins, state }))
   } catch (e) {
+    console.log('render failed', e, stringifyState(state))
     return wrapOutput()
   }
 


### PR DESCRIPTION
as a consequence of https://github.com/edtr-io/edtr-io/pull/235 this improves our log messages, because the current handling didn't help much in noticing the issue...

@inyono should we include Sentry-logging there as well?