### PR TITLE
fix: use ajax request instead of iframe for serlo injections

### DIFF
--- a/packages/private/edtr-io/src/plugins.ts
+++ b/packages/private/edtr-io/src/plugins.ts
@@ -30,7 +30,6 @@ import { importantStatementPlugin } from '@edtr-io/plugin-important-statement'
 import { inputExercisePlugin } from '@edtr-io/plugin-input-exercise'
 import { createRowsPlugin, PluginRegistry } from '@edtr-io/plugin-rows'
 import { scMcExercisePlugin } from '@edtr-io/plugin-sc-mc-exercise'
-import { serloInjectionPlugin } from '@edtr-io/plugin-serlo-injection'
 import { solutionPlugin } from '@edtr-io/plugin-solution'
 import { spoilerPlugin } from '@edtr-io/plugin-spoiler'
 import { videoPlugin } from '@edtr-io/plugin-video'
@@ -50,6 +49,7 @@ import { userTypePlugin } from './plugins/types/user'
 import { videoTypePlugin } from './plugins/types/video'
 import { errorPlugin } from './plugins/error'
 import { imagePlugin } from './plugins/image'
+import { injectionPlugin } from './plugins/injection'
 import { layoutPlugin } from './plugins/layout'
 import { tablePlugin } from './plugins/table'
 
@@ -65,7 +65,7 @@ export function createPlugins(
     hint: hintPlugin,
     image: imagePlugin,
     important: importantStatementPlugin,
-    injection: serloInjectionPlugin,
+    injection: injectionPlugin,
     inputExercise: inputExercisePlugin,
     layout: layoutPlugin,
     rows: createRowsPlugin(registry),

--- a/packages/private/edtr-io/src/plugins/injection.tsx
+++ b/packages/private/edtr-io/src/plugins/injection.tsx
@@ -1,0 +1,169 @@
+import axios from 'axios'
+import {
+  OverlayInput,
+  PrimarySettings,
+  EditorInput,
+  PreviewOverlay,
+  styled,
+  createIcon,
+  Icon,
+  faNewspaper
+} from '@edtr-io/editor-ui'
+import {
+  StatefulPluginEditorProps,
+  string,
+  StatefulPlugin
+} from '@edtr-io/plugin'
+import * as React from 'react'
+
+/* global */
+declare const Common: {
+  trigger: (type: string, context?: HTMLDivElement | null) => void
+}
+
+export const injectionState = string()
+export const injectionPlugin: StatefulPlugin<typeof injectionState> = {
+  Component: InjectionEditor,
+  state: injectionState,
+  title: 'Serlo Inhalt',
+  description: 'Binde einen Inhalt von serlo.org via ID ein',
+  icon: createIcon(faNewspaper)
+}
+
+export function InjectionRenderer(props: { src: string }) {
+  const [loaded, setLoaded] = React.useState('')
+  const ref = React.useRef<HTMLDivElement>(null)
+
+  React.useEffect(() => {
+    const src = createURL(props.src)
+
+    axios
+      .get<{ response: string }>(src, {
+        headers: {
+          'X-Requested-With': 'XMLHttpRequest'
+        }
+      })
+      .then(({ data }) => {
+        setLoaded(data.response)
+        setTimeout(() => {
+          if (ref.current) {
+            Common.trigger('new context', ref.current)
+          }
+        })
+      })
+      .catch(e => {
+        setLoaded(
+          '<div class="alert alert-info">Illegal injection found </div>'
+        )
+      })
+  }, [props.src])
+
+  if (loaded) {
+    return (
+      <div className="panel panel-default">
+        <div
+          className="panel-body"
+          ref={ref}
+          dangerouslySetInnerHTML={{ __html: loaded }}
+        />
+      </div>
+    )
+  }
+
+  const src = createURL(props.src)
+  return (
+    <div>
+      <a href={src}>Serlo Inhalt {src}</a>
+    </div>
+  )
+}
+
+function createURL(id: string) {
+  if (id.startsWith('/') || id.startsWith('\\')) {
+    return '/' + id.substring(1, id.length)
+  }
+  const match = id.match(/^https?:\/\/[^./]+\.serlo\.[^./]+\/(.+)$/g)
+  if (match) {
+    return '/' + match[1]
+  }
+  return '/' + id
+}
+
+const PlaceholderWrapper = styled.div({
+  position: 'relative',
+  width: '100%',
+  textAlign: 'center'
+})
+
+function InjectionEditor(
+  props: StatefulPluginEditorProps<typeof injectionState> & {
+    renderIntoExtendedSettings?: (children: React.ReactNode) => React.ReactNode
+  }
+) {
+  const [cache, setCache] = React.useState(props.state.value)
+  const [preview, setPreview] = React.useState(false)
+
+  React.useEffect(() => {
+    const timeout = setTimeout(() => {
+      setCache(props.state.value)
+    }, 2000)
+    return () => {
+      clearTimeout(timeout)
+    }
+  }, [props.focused, props.state.value])
+
+  if (!props.editable) {
+    return <InjectionRenderer src={props.state.value} />
+  }
+
+  return (
+    <React.Fragment>
+      {cache ? (
+        <PreviewOverlay
+          focused={props.focused || false}
+          onChange={nextActive => {
+            setPreview(nextActive)
+            if (nextActive) {
+              setCache(props.state.value)
+            }
+          }}
+        >
+          <InjectionRenderer src={cache} />
+        </PreviewOverlay>
+      ) : (
+        <PlaceholderWrapper>
+          <Icon icon={faNewspaper} size="5x" />
+        </PlaceholderWrapper>
+      )}
+      {props.focused && !preview ? (
+        <PrimarySettings>
+          <EditorInput
+            label="Serlo ID:"
+            placeholder="123456"
+            value={props.state.value}
+            onChange={e => {
+              props.state.set(e.target.value)
+            }}
+            textfieldWidth="30%"
+            editorInputWidth="100%"
+            ref={props.defaultFocusRef}
+          />
+        </PrimarySettings>
+      ) : null}
+      {props.renderIntoExtendedSettings
+        ? props.renderIntoExtendedSettings(
+            <React.Fragment>
+              <OverlayInput
+                label="Serlo ID:"
+                placeholder="123456"
+                value={props.state.value}
+                onChange={e => {
+                  props.state.set(e.target.value)
+                }}
+              />
+            </React.Fragment>
+          )
+        : null}
+    </React.Fragment>
+  )
+}

--- a/packages/public/server/src/module/Entity/src/Entity/Controller/PageController.php
+++ b/packages/public/server/src/module/Entity/src/Entity/Controller/PageController.php
@@ -48,7 +48,7 @@ class PageController extends AbstractController
         }
 
         $type = $this->moduleOptions->getType($entity->getType()->getName());
-        if ($type->hasComponent('redirect')) {
+        if ($type->hasComponent('redirect') && !$this->getRequest()->isXmlHttpRequest()) {
             /* @var $redirect RedirectOptions */
             $redirect = $type->getComponent('redirect');
 


### PR DESCRIPTION
### Fixed
- Use ajax request instead of iframe to fix analytics issues (ref #94)
- Revert: Do not redirect ajax requests - fixes #93 