### PR TITLE
converter for solution-step plugin

### DIFF
--- a/packages/private/edtr-io/src/deserialize.ts
+++ b/packages/private/edtr-io/src/deserialize.ts
@@ -542,9 +542,19 @@ export function deserialize({
       changes: '',
       // FIXME: solutions don't have a title
       title: '',
-      content: serializeEditorState(
-        toEdtr(deserializeEditorState(state.content))
-      )
+      content: serializeEditorState({
+        plugin: 'solutionStep',
+        state: {
+          introduction: { plugin: 'text' },
+          solutionSteps: [
+            {
+              type: 'step',
+              isHalf: false,
+              content: toEdtr(deserializeEditorState(state.content))
+            }
+          ]
+        }
+      })
     }
   }
 

--- a/packages/private/legacy-editor-to-editor/src/splishToEdtr/types.ts
+++ b/packages/private/legacy-editor-to-editor/src/splishToEdtr/types.ts
@@ -78,6 +78,7 @@ export type OtherPlugin = {
     | 'important'
     | 'injection'
     | 'inputExercise'
+    | 'solutionStep'
     | 'spoiler'
     | 'scMcExercise'
     | 'table'


### PR DESCRIPTION
converted solutions use the solution-step plugin instead of the rows plugin.

can be merged after solution-step plugin in edtr.io is ready