### PR TITLE
server: Remove legacy HTML attributes (fixes #108)

### DIFF
--- a/packages/public/server/src/module/Ui/templates/entity/page/course.twig
+++ b/packages/public/server/src/module/Ui/templates/entity/page/course.twig
@@ -24,10 +24,7 @@
 {% include 'entity/page/partials/placeholders' %}
 <div itemscope itemtype="http://schema.org/Article">
     <div class="page-header">
-        <div class="editable"
-             data-id="{{ entity.getId() }}"
-             data-edit-field="title"
-             data-edit-type="text">
+        <div class="editable">
             <h1><span itemprop="name">{{ title }}</span></h1>
         </div>
         {% include 'entity/view/partials/actions/big' %}

--- a/packages/public/server/src/module/Ui/templates/entity/view/article.twig
+++ b/packages/public/server/src/module/Ui/templates/entity/view/article.twig
@@ -23,7 +23,7 @@
 {% set revision = entity.getCurrentRevision() %}
 {% set content = renderer().toHtml(revision.get('content')) %}
 <article>
-    <section class="editable" data-id="{{ entity.getId() }}" data-edit-field="content" data-edit-type="ory">
+    <section class="editable">
         {{ content }}
     </section>
 

--- a/packages/public/server/src/module/Ui/templates/entity/view/course-page.twig
+++ b/packages/public/server/src/module/Ui/templates/entity/view/course-page.twig
@@ -44,13 +44,13 @@
 
 <div class="row">
     <div class="col-xs-12">
-        <h1 class="heading-content editable" data-id="{{ entity.getId() }}" data-edit-field="title" data-edit-type="text">
+        <h1 class="heading-content editable">
             {{ revision.get('title') }}
         </h1>
     </div>
 </div>
 <div class="row">
-    <div class="col-xs-12 editable" data-id="{{ entity.getId() }}" data-edit-field="content" data-edit-type="ory">
+    <div class="col-xs-12 editable">
         {{ content }}
     </div>
 </div>

--- a/packages/public/server/src/module/Ui/templates/entity/view/event.twig
+++ b/packages/public/server/src/module/Ui/templates/entity/view/event.twig
@@ -23,7 +23,7 @@
 {% set revision = entity.getCurrentRevision() %}
 {% set content = renderer().toHtml(revision.get('content')) %}
 <article>
-    <section class="editable" data-id="{{ entity.getId() }}" data-edit-field="content" data-edit-type="ory">
+    <section class="editable">
         {{ content }}
     </section>
 </article>

--- a/packages/public/server/src/module/Ui/templates/entity/view/partials/input-challenge.twig
+++ b/packages/public/server/src/module/Ui/templates/entity/view/partials/input-challenge.twig
@@ -36,11 +36,7 @@
                data-wrong-inputs="{{ wrongInputs | escape('html_attr') }}">
     </div>
     <div class="row">
-        <div class="col-xs-12 input-challenge-feedback pull-right collapse editable"
-             data-id="{{ entity.getId() }}"
-             data-edit-field="feedback"
-             data-edit-type="ory"
-        ></div>
+        <div class="col-xs-12 input-challenge-feedback pull-right collapse editable"></div>
     </div>
     <div class="input-challenge-solution">
         {% if showSolution %}

--- a/packages/public/server/src/module/Ui/templates/entity/view/partials/math-puzzle.twig
+++ b/packages/public/server/src/module/Ui/templates/entity/view/partials/math-puzzle.twig
@@ -30,11 +30,7 @@
     <section class="row">
         <div class="col-xs-12 col-sm-11">
             <div class="math-puzzle" data-source="{{ source }}">
-                <div class="exercise editable"
-                     data-id="{{ entity.getId() }}"
-                     data-edit-field="content"
-                     data-edit-type="ory"
-                >
+                <div class="exercise editable">
                     {{ renderer().toHtml(revision.get('content')) | raw }}
                 </div>
             </div>

--- a/packages/public/server/src/module/Ui/templates/entity/view/partials/multiple-choice-answer.twig
+++ b/packages/public/server/src/module/Ui/templates/entity/view/partials/multiple-choice-answer.twig
@@ -33,19 +33,12 @@
 <div class="col-sm-3 multiple-choice-answer-group" itemprop="articleBody">
     <button class="btn multiple-choice-answer-content button-default editable"
             name="multiple-choice-answer-choice-{{  parent.getID() }}"
-            data-correct="{{ right }}"
-            data-id="{{ entity.getId() }}"
-            data-edit-field="content"
-            data-edit-type="ory"
-    >
+            data-correct="{{ right }}">
         {{ displayContent | raw }}
     </button>
     {% if not right %}
         <div class="multiple-choice-answer-feedback collapse">
-            <div class="alert alert-warning editable"
-                 data-id="{{ entity.getId() }}"
-                 data-edit-field="feedback"
-                 data-edit-type="ory">
+            <div class="alert alert-warning editable">
                 {{ feedback | raw }}
             </div>
         </div>

--- a/packages/public/server/src/module/Ui/templates/entity/view/partials/single-choice-answer.twig
+++ b/packages/public/server/src/module/Ui/templates/entity/view/partials/single-choice-answer.twig
@@ -33,20 +33,12 @@
 <div class="col-sm-3 single-choice-answer-group" itemprop="articleBody">
     <button class="btn single-choice-answer-content button-default editable"
             name="single-choice-answer-choice-{{  parent.getID() }}"
-            data-correct="{{ right }}"
-            data-id="{{ entity.getId() }}"
-            data-edit-field="content"
-            data-edit-type="ory"
-    >
+            data-correct="{{ right }}">
         {{ displayContent | raw }}
     </button>
     {% if not right %}
     <div class="single-choice-answer-feedback collapse">
-        <div class="alert alert-warning editable"
-             data-id="{{ entity.getId() }}"
-             data-edit-field="feedback"
-             data-edit-type="ory"
-        >
+        <div class="alert alert-warning editable">
             {{ feedback | raw }}
         </div>
     </div>

--- a/packages/public/server/src/module/Ui/templates/entity/view/partials/text-exercise.twig
+++ b/packages/public/server/src/module/Ui/templates/entity/view/partials/text-exercise.twig
@@ -35,11 +35,7 @@
 {% set inputChallenge = inputChallenge().fetchInput(entity) %}
 <article class="text-exercise  {{ multipleChoices|length>4 or singleChoices|length>4 ? 'extended' }}" itemscope itemtype="http://schema.org/Article">
     <section class="row">
-        <div class="col-xs-12 col-sm-11 editable" itemprop="articleBody"
-             data-id="{{ entity.getId() }}"
-             data-edit-field="content"
-             data-edit-type="ory"
-        >
+        <div class="col-xs-12 col-sm-11 editable" itemprop="articleBody">
             {{ renderer().toHtml(revision.get('content')) | raw }}
         </div>
         <div class="hidden-xs col-sm-1" style="padding:0">

--- a/packages/public/server/src/module/Ui/templates/entity/view/text-exercise-group.twig
+++ b/packages/public/server/src/module/Ui/templates/entity/view/text-exercise-group.twig
@@ -22,12 +22,7 @@
 {% set title = 'text-exercise-group' | trans %}
 <article class="exercisegroup">
     <section class="row" style="margin-right:0px">
-        <div class="col-xs-12 col-sm-11 editable"
-             itemprop="articleBody"
-             data-id="{{ entity.getId() }}"
-             data-edit-field="content"
-             data-edit-type="ory"
-        >
+        <div class="col-xs-12 col-sm-11 editable" itemprop="articleBody">
             {{ renderer().toHtml(entity.getCurrentRevision().get('content')) }}
         </div>
         <div class="col-xs-hidden col-sm-1" style="padding:0">

--- a/packages/public/server/src/module/Ui/templates/entity/view/text-hint.twig
+++ b/packages/public/server/src/module/Ui/templates/entity/view/text-hint.twig
@@ -34,10 +34,7 @@
             </strong>
         </div>
         <div class="list-group">
-            <div class="list-group-item editable"
-                 data-id="{{ entity.getId() }}"
-                 data-edit-field="content"
-                 data-edit-type="ory">
+            <div class="list-group-item editable">
                 {% if revision %}
                     {{ renderer().toHtml(revision.get('content')) | raw }}
                 {% elseif not entity.getHead() %}

--- a/packages/public/server/src/module/Ui/templates/entity/view/text-solution.twig
+++ b/packages/public/server/src/module/Ui/templates/entity/view/text-solution.twig
@@ -32,11 +32,7 @@
                     </div>
                 </div>
                 <div class="row">
-                    <div class="col-xs-12 editable"
-                         data-id="{{ entity.getId() }}"
-                         data-edit-field="content"
-                         data-edit-type="ory"
-                    >
+                    <div class="col-xs-12 editable">
                         {% if revision %}
                             {{ renderer().toHtml(revision.get('content')) | raw }}
                         {% elseif not entity.getHead() %}

--- a/packages/public/server/src/module/Ui/templates/page/partials/head.twig
+++ b/packages/public/server/src/module/Ui/templates/page/partials/head.twig
@@ -21,10 +21,7 @@
  #}
 {% do normalize().headMeta(revision).headTitle(revision) %}
 {% set title = revision.getTitle() %}
-<div class="page-header editable"
-     data-id="{{ page.getId() }}"
-     data-edit-field="title"
-     data-edit-type="text">
+<div class="page-header editable">
     {% set controls = include('page/partials/controls') %}
     {% do placeholder('controls').set(controls) %}
     {% do placeholder('breadcrumbs').set('<li><span>' ~ title ~ '</span></li>') %}

--- a/packages/public/server/src/module/Ui/templates/page/revision/view.twig
+++ b/packages/public/server/src/module/Ui/templates/page/revision/view.twig
@@ -25,7 +25,7 @@
         <header>
             {% include 'page/partials/head' %}
         </header>
-        <section itemprop="articleBody" class="editable" data-id="{{ page.getId() }}" data-edit-field="content" data-edit-type="ory">
+        <section itemprop="articleBody" class="editable">
             {{ renderer().toHtml(revision.getContent()) }}
         </section>
     </article>


### PR DESCRIPTION
Remove legacy HTML attributes for the ory editor introduced in https://github.com/serlo/athene2/commit/717e2373c