### PR TITLE
yarn: Add --stream to lerna for "start:client"

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "c": "docker-compose run --rm server-composer composer",
     "c-dev": "docker-compose run --rm server-composer-dev-tools composer",
     "start": "npm-run-all start:server start:client",
-    "start:client": "lerna run start --scope=@serlo/serlo-org-client",
+    "start:client": "lerna run --stream --scope=@serlo/serlo-org-client start",
     "prestart:server": "yarn c install && yarn c-dev install",
     "start:server": "docker-compose up --build --detach",
     "stop:server": "docker-compose stop",


### PR DESCRIPTION
With the --stream option the error output logs of webpack-dev-server are
piped to the lerna output (which is not the case without this option,
see https://github.com/lerna/lerna/issues/449 ). Thus, with this option we see when we
made errors in our scripts or stylesheets.