### PR TITLE
Make changes a mandatory field

### DIFF
--- a/packages/private/edtr-io/src/plugins/types/common.tsx
+++ b/packages/private/edtr-io/src/plugins/types/common.tsx
@@ -188,11 +188,7 @@ export function Controls(props: OwnProps) {
             }}
             bsStyle="success"
             disabled={!maySave() || pending}
-            title={
-              maySave()
-                ? undefined
-                : 'Du musst zuerst die Lizenzbedingungen akzeptieren und die Änderungen ausfüllen'
-            }
+            title={getSaveHint()}
           >
             {pending ? 'Speichert ...' : 'Speichern'}
           </BSButton>
@@ -226,10 +222,25 @@ export function Controls(props: OwnProps) {
     return <button className="btn btn-success" {...buttonProps} />
   }
 
+  function licenseAccepted() {
+    return !props.license || agreement
+  }
+  function changesFilledIn() {
+    return !props.changes || props.changes.value
+  }
   function maySave() {
-    const licenseAccepted = !props.license || agreement
-    const changesSet = !props.changes || props.changes.value
-    return licenseAccepted && changesSet
+    return licenseAccepted() && changesFilledIn()
+  }
+
+  function getSaveHint() {
+    if (maySave()) return undefined
+    if (licenseAccepted() && !changesFilledIn()) {
+      return 'Du musst zuerst die Änderungen ausfüllen.'
+    } else if(!licenseAccepted() && changesFilledIn()) {
+      return 'Du musst zuerst die Lizenzbedingungen akzeptieren.'
+    } else {
+      return 'Du musst zuerst die Lizenzbedingungen akzeptieren und die Änderungen ausfüllen'
+    }
   }
 
   function handleSave() {

--- a/packages/private/edtr-io/src/plugins/types/common.tsx
+++ b/packages/private/edtr-io/src/plugins/types/common.tsx
@@ -236,7 +236,7 @@ export function Controls(props: OwnProps) {
     if (maySave()) return undefined
     if (licenseAccepted() && !changesFilledIn()) {
       return 'Du musst zuerst die Änderungen ausfüllen.'
-    } else if(!licenseAccepted() && changesFilledIn()) {
+    } else if (!licenseAccepted() && changesFilledIn()) {
       return 'Du musst zuerst die Lizenzbedingungen akzeptieren.'
     } else {
       return 'Du musst zuerst die Lizenzbedingungen akzeptieren und die Änderungen ausfüllen'

--- a/packages/private/edtr-io/src/plugins/types/common.tsx
+++ b/packages/private/edtr-io/src/plugins/types/common.tsx
@@ -191,7 +191,7 @@ export function Controls(props: OwnProps) {
             title={
               maySave()
                 ? undefined
-                : 'Du musst zuerst die Lizenzbedingungen akzeptieren'
+                : 'Du musst zuerst die Lizenzbedingungen akzeptieren und die Änderungen ausfüllen'
             }
           >
             {pending ? 'Speichert ...' : 'Speichern'}
@@ -227,8 +227,9 @@ export function Controls(props: OwnProps) {
   }
 
   function maySave() {
-    if (!props.license) return true
-    return agreement
+    const licenseAccepted = !props.license || agreement
+    const changesSet = !props.changes || props.changes.value
+    return licenseAccepted && changesSet
   }
 
   function handleSave() {

--- a/packages/public/client/package.json
+++ b/packages/public/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serlo/serlo-org-client",
-  "version": "5.6.0",
+  "version": "5.7.0",
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "cross-env NODE_ENV=production webpack --config webpack.prod.config --output-public-path=https://packages.serlo.org/serlo-org-client@$npm_package_version/",

--- a/packages/public/server/package.json
+++ b/packages/public/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serlo/serlo-org-server",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "license": "Apache-2.0",
   "author": "Serlo Education e.V.",
   "scripts": {

--- a/packages/public/server/src/module/Entity/src/Entity/Form/AppletForm.php
+++ b/packages/public/server/src/module/Entity/src/Entity/Form/AppletForm.php
@@ -23,6 +23,7 @@
 
 namespace Entity\Form;
 
+use Entity\Form\Element\Changes;
 use Csrf\Form\Element\CsrfToken;
 use Common\Form\Element\EditorState;
 use Common\Form\Element\Title;
@@ -48,12 +49,7 @@ class AppletForm extends Form
         $this->add((new Url('url'))->setAttribute('id', 'url')->setLabel('Applet Url:'));
         $this->add((new EditorState('content'))->setLabel('Description:'));
         $this->add((new EditorState('reasoning'))->setLabel('Reasoning:'));
-        $this->add(
-            (new Textarea('changes'))->setAttribute('id', 'changes')->setLabel('Changes:')->setAttribute(
-                'class',
-                'plain'
-            )
-        );
+        $this->add(new Changes());
         $this->add(new Element\MetaTitle());
         $this->add(new Element\MetaDescription());
         $this->add(new AgreementFieldset($license));
@@ -83,7 +79,6 @@ class AppletForm extends Form
             ]
         );
         $inputFilter->add(['name' => 'content', 'required' => true]);
-        $inputFilter->add(['name' => 'changes', 'required' => false, 'filters' => [['name' => 'StripTags']]]);
         $this->setInputFilter($inputFilter);
     }
 }

--- a/packages/public/server/src/module/Entity/src/Entity/Form/ArticleForm.php
+++ b/packages/public/server/src/module/Entity/src/Entity/Form/ArticleForm.php
@@ -22,6 +22,7 @@
  */
 namespace Entity\Form;
 
+use Entity\Form\Element\Changes;
 use Csrf\Form\Element\CsrfToken;
 use Common\Form\Element\EditorState;
 use Common\Form\Element\Title;
@@ -44,12 +45,7 @@ class ArticleForm extends Form
         $this->add(new Title());
         $this->add((new EditorState('content'))->setLabel('Content:'));
         $this->add((new EditorState('reasoning'))->setLabel('Reasoning:'));
-        $this->add(
-            (new Textarea('changes'))->setAttribute('id', 'changes')->setLabel('Changes:')->setAttribute(
-                'class',
-                'plain control'
-            )
-        );
+        $this->add(new Changes());
         $this->add(new Element\MetaTitle());
         $this->add(new Element\MetaDescription());
         $this->add(new AgreementFieldset($license));
@@ -57,7 +53,6 @@ class ArticleForm extends Form
 
         $inputFilter = new InputFilter('article');
         $inputFilter->add(['name' => 'content', 'required' => true]);
-        $inputFilter->add(['name' => 'changes', 'required' => false, 'filters' => [['name' => 'StripTags']]]);
 
         $this->setInputFilter($inputFilter);
     }

--- a/packages/public/server/src/module/Entity/src/Entity/Form/Element/Changes.php
+++ b/packages/public/server/src/module/Entity/src/Entity/Form/Element/Changes.php
@@ -20,34 +20,39 @@
  * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
  * @link      https://github.com/serlo-org/serlo.org for the canonical source repository
  */
-namespace Entity\Form;
+namespace Entity\Form\Element;
 
-use Entity\Form\Element\Changes;
-use Csrf\Form\Element\CsrfToken;
-use Common\Form\Element\EditorState;
-use License\Entity\LicenseInterface;
-use License\Form\AgreementFieldset;
 use Zend\Form\Element\Textarea;
-use Zend\Form\Form;
-use Zend\InputFilter\InputFilter;
+use Zend\InputFilter\InputProviderInterface;
 
-class TextExerciseForm extends Form
+class Changes extends Textarea implements InputProviderInterface
 {
-    public function __construct(LicenseInterface $license)
+    public function __construct()
     {
-        parent::__construct('text-exercise');
-        $this->add(new CsrfToken());
+        parent::__construct('changes');
 
-        $this->setAttribute('method', 'post');
-        $this->setAttribute('class', 'clearfix');
+        $this->setAttribute('id', 'changes');
+        $this->setLabel('Changes:');
+        $this->setAttribute(
+            'class',
+            'plain'
+        );
+    }
 
-        $this->add((new EditorState('content'))->setLabel('Content:'));
-        $this->add(new Changes());
-        $this->add(new AgreementFieldset($license));
-        $this->add(new Controls());
-
-        $inputFilter = new InputFilter('text-exercise');
-        $inputFilter->add(['name' => 'content', 'required' => true]);
-        $this->setInputFilter($inputFilter);
+    /**
+     * Should return an array specification compatible with
+     * {@link Zend\InputFilter\Factory::createInputFilter()}.
+     *
+     * @return array
+     */
+    public function getInputSpecification()
+    {
+        return [
+            'name' => $this->getName(),
+            'required' => true,
+            'filters' => [
+                ['name' => 'StripTags'],
+            ],
+        ];
     }
 }

--- a/packages/public/server/src/module/Entity/src/Entity/Form/EventForm.php
+++ b/packages/public/server/src/module/Entity/src/Entity/Form/EventForm.php
@@ -22,6 +22,7 @@
  */
 namespace Entity\Form;
 
+use Entity\Form\Element\Changes;
 use Csrf\Form\Element\CsrfToken;
 use Common\Form\Element\EditorState;
 use Common\Form\Element\Title;
@@ -43,12 +44,7 @@ class EventForm extends Form
 
         $this->add(new Title());
         $this->add((new EditorState('content'))->setLabel('Content:'));
-        $this->add(
-            (new Textarea('changes'))->setAttribute('id', 'changes')->setLabel('Changes:')->setAttribute(
-                'class',
-                'plain control'
-            )
-        );
+        $this->add(new Changes());
         $this->add(new Element\MetaTitle());
         $this->add(new Element\MetaDescription());
         $this->add(new AgreementFieldset($license));

--- a/packages/public/server/src/module/Entity/src/Entity/Form/GroupedTextExerciseForm.php
+++ b/packages/public/server/src/module/Entity/src/Entity/Form/GroupedTextExerciseForm.php
@@ -22,6 +22,7 @@
  */
 namespace Entity\Form;
 
+use Entity\Form\Element\Changes;
 use Csrf\Form\Element\CsrfToken;
 use Common\Form\Element\EditorState;
 use License\Entity\LicenseInterface;
@@ -41,18 +42,12 @@ class GroupedTextExerciseForm extends Form
         $this->setAttribute('class', 'clearfix');
 
         $this->add((new EditorState('content'))->setLabel('Content:'));
-        $this->add(
-            (new Textarea('changes'))->setAttribute('id', 'changes')->setLabel('Changes:')->setAttribute(
-                'class',
-                'plain control'
-            )
-        );
+        $this->add(new Changes());
         $this->add(new AgreementFieldset($license));
         $this->add(new Controls());
 
         $inputFilter = new InputFilter('grouped-text-exercise');
         $inputFilter->add(['name' => 'content', 'required' => true]);
-        $inputFilter->add(['name' => 'changes', 'required' => false, 'filters' => [['name' => 'StripTags']]]);
         $this->setInputFilter($inputFilter);
     }
 }

--- a/packages/public/server/src/module/Entity/src/Entity/Form/InputChallengeForm.php
+++ b/packages/public/server/src/module/Entity/src/Entity/Form/InputChallengeForm.php
@@ -22,6 +22,7 @@
  */
 namespace Entity\Form;
 
+use Entity\Form\Element\Changes;
 use Csrf\Form\Element\CsrfToken;
 use Common\Form\Element\EditorState;
 use License\Entity\LicenseInterface;
@@ -43,18 +44,12 @@ class InputChallengeForm extends Form
 
         $this->add((new Text('solution'))->setAttribute('id', 'solution')->setLabel('Solution:'));
         $this->add((new EditorState('feedback'))->setLabel('Feedback:'));
-        $this->add(
-            (new Textarea('changes'))->setAttribute('id', 'changes')->setLabel('Changes:')->setAttribute(
-                'class',
-                'plain control'
-            )
-        );
+        $this->add(new Changes());
         $this->add(new AgreementFieldset($license));
         $this->add(new Controls());
 
         $inputFilter = new InputFilter('input-challenge');
         $inputFilter->add(['name' => 'solution', 'required' => true]);
-        $inputFilter->add(['name' => 'changes', 'required' => false, 'filters' => [['name' => 'StripTags']]]);
         $this->setInputFilter($inputFilter);
     }
 }

--- a/packages/public/server/src/module/Entity/src/Entity/Form/MathPuzzleForm.php
+++ b/packages/public/server/src/module/Entity/src/Entity/Form/MathPuzzleForm.php
@@ -22,6 +22,7 @@
  */
 namespace Entity\Form;
 
+use Entity\Form\Element\Changes;
 use Csrf\Form\Element\CsrfToken;
 use Common\Form\Element\EditorState;
 use License\Entity\LicenseInterface;
@@ -47,19 +48,13 @@ class MathPuzzleForm extends Form
                 'plain'
             )
         );
-        $this->add(
-            (new Textarea('changes'))->setAttribute('id', 'changes')->setLabel('Changes:')->setAttribute(
-                'class',
-                'plain control'
-            )
-        );
+        $this->add(new Changes());
         $this->add(new AgreementFieldset($license));
         $this->add(new Controls());
 
         $inputFilter = new InputFilter('math-puzzle');
         $inputFilter->add(['name' => 'content', 'required' => true]);
         $inputFilter->add(['name' => 'source', 'required' => true]);
-        $inputFilter->add(['name' => 'changes', 'required' => false, 'filters' => [['name' => 'StripTags']]]);
         $this->setInputFilter($inputFilter);
     }
 }

--- a/packages/public/server/src/module/Entity/src/Entity/Form/ModuleForm.php
+++ b/packages/public/server/src/module/Entity/src/Entity/Form/ModuleForm.php
@@ -22,6 +22,7 @@
  */
 namespace Entity\Form;
 
+use Entity\Form\Element\Changes;
 use Csrf\Form\Element\CsrfToken;
 use Common\Form\Element\EditorState;
 use Common\Form\Element\Title;
@@ -46,19 +47,13 @@ class ModuleForm extends Form
         $this->add(
             (new EditorState('reasoning'))->setLabel('Reasoning:')
         );
-        $this->add(
-            (new Textarea('changes'))->setAttribute('id', 'changes')->setLabel('Changes:')->setAttribute(
-                'class',
-                'plain control'
-            )
-        );
+        $this->add(new Changes());
 
         $this->add(new Element\MetaDescription());
         $this->add(new AgreementFieldset($license));
         $this->add(new Controls());
 
         $inputFilter = new InputFilter('course');
-        $inputFilter->add(['name' => 'changes', 'required' => false, 'filters' => [['name' => 'StripTags']]]);
         $this->setInputFilter($inputFilter);
     }
 }

--- a/packages/public/server/src/module/Entity/src/Entity/Form/ModulePageForm.php
+++ b/packages/public/server/src/module/Entity/src/Entity/Form/ModulePageForm.php
@@ -22,6 +22,7 @@
  */
 namespace Entity\Form;
 
+use Entity\Form\Element\Changes;
 use Csrf\Form\Element\CsrfToken;
 use Common\Form\Element\EditorState;
 use Common\Form\Element\Title;
@@ -54,18 +55,12 @@ class ModulePageForm extends Form
         $select->setAttribute('class', 'meta');
         $this->add($select);
         $this->add((new EditorState('content'))->setLabel('Content:'));
-        $this->add(
-            (new Textarea('changes'))->setAttribute('id', 'changes')->setLabel('Changes:')->setAttribute(
-                'class',
-                'plain control'
-            )
-        );
+        $this->add(new Changes());
         $this->add(new AgreementFieldset($license));
         $this->add(new Controls());
 
         $inputFilter = new InputFilter('course-page');
         $inputFilter->add(['name' => 'content', 'required' => true]);
-        $inputFilter->add(['name' => 'changes', 'required' => false, 'filters' => [['name' => 'StripTags']]]);
         $this->setInputFilter($inputFilter);
     }
 }

--- a/packages/public/server/src/module/Entity/src/Entity/Form/MultipleChoiceRightAnswerForm.php
+++ b/packages/public/server/src/module/Entity/src/Entity/Form/MultipleChoiceRightAnswerForm.php
@@ -22,6 +22,7 @@
  */
 namespace Entity\Form;
 
+use Entity\Form\Element\Changes;
 use Csrf\Form\Element\CsrfToken;
 use Common\Form\Element\EditorState;
 use License\Entity\LicenseInterface;
@@ -41,18 +42,12 @@ class MultipleChoiceRightAnswerForm extends Form
         $this->setAttribute('class', 'clearfix');
 
         $this->add((new EditorState('content'))->setLabel('Content:'));
-        $this->add(
-            (new Textarea('changes'))->setAttribute('id', 'changes')->setLabel('Changes:')->setAttribute(
-                'class',
-                'plain control'
-            )
-        );
+        $this->add(new Changes());
         $this->add(new AgreementFieldset($license));
         $this->add(new Controls());
 
         $inputFilter = new InputFilter('multiple-choice-answer');
         $inputFilter->add(['name' => 'content', 'required' => true]);
-        $inputFilter->add(['name' => 'changes', 'required' => false, 'filters' => [['name' => 'StripTags']]]);
         $this->setInputFilter($inputFilter);
     }
 }

--- a/packages/public/server/src/module/Entity/src/Entity/Form/MultipleChoiceWrongAnswerForm.php
+++ b/packages/public/server/src/module/Entity/src/Entity/Form/MultipleChoiceWrongAnswerForm.php
@@ -22,6 +22,7 @@
  */
 namespace Entity\Form;
 
+use Entity\Form\Element\Changes;
 use Csrf\Form\Element\CsrfToken;
 use Common\Form\Element\EditorState;
 use License\Entity\LicenseInterface;
@@ -42,18 +43,12 @@ class MultipleChoiceWrongAnswerForm extends Form
 
         $this->add((new EditorState('content'))->setLabel('Content:'));
         $this->add((new EditorState('feedback'))->setLabel('Feedback:'));
-        $this->add(
-            (new Textarea('changes'))->setAttribute('id', 'changes')->setLabel('Changes:')->setAttribute(
-                'class',
-                'plain control'
-            )
-        );
+        $this->add(new Changes());
         $this->add(new AgreementFieldset($license));
         $this->add(new Controls());
 
         $inputFilter = new InputFilter('multiple-choice-answer');
         $inputFilter->add(['name' => 'content', 'required' => true]);
-        $inputFilter->add(['name' => 'changes', 'required' => false, 'filters' => [['name' => 'StripTags']]]);
         $this->setInputFilter($inputFilter);
     }
 }

--- a/packages/public/server/src/module/Entity/src/Entity/Form/SingleChoiceAnswerForm.php
+++ b/packages/public/server/src/module/Entity/src/Entity/Form/SingleChoiceAnswerForm.php
@@ -22,6 +22,7 @@
  */
 namespace Entity\Form;
 
+use Entity\Form\Element\Changes;
 use Csrf\Form\Element\CsrfToken;
 use Common\Form\Element\EditorState;
 use License\Entity\LicenseInterface;
@@ -42,18 +43,12 @@ class SingleChoiceAnswerForm extends Form
 
         $this->add((new EditorState('content'))->setLabel('Content:'));
         $this->add((new EditorState('feedback'))->setLabel('Feedback:'));
-        $this->add(
-            (new Textarea('changes'))->setAttribute('id', 'changes')->setLabel('Changes:')->setAttribute(
-                'class',
-                'plain control'
-            )
-        );
+        $this->add(new Changes());
         $this->add(new AgreementFieldset($license));
         $this->add(new Controls());
 
         $inputFilter = new InputFilter('single-choice-answer');
         $inputFilter->add(['name' => 'content', 'required' => true]);
-        $inputFilter->add(['name' => 'changes', 'required' => false, 'filters' => [['name' => 'StripTags']]]);
         $this->setInputFilter($inputFilter);
     }
 }

--- a/packages/public/server/src/module/Entity/src/Entity/Form/TextExerciseGroupForm.php
+++ b/packages/public/server/src/module/Entity/src/Entity/Form/TextExerciseGroupForm.php
@@ -22,6 +22,7 @@
  */
 namespace Entity\Form;
 
+use Entity\Form\Element\Changes;
 use Csrf\Form\Element\CsrfToken;
 use Common\Form\Element\EditorState;
 use License\Entity\LicenseInterface;
@@ -41,18 +42,12 @@ class TextExerciseGroupForm extends Form
         $this->setAttribute('class', 'clearfix');
 
         $this->add((new EditorState('content'))->setLabel('Content:'));
-        $this->add(
-            (new Textarea('changes'))->setAttribute('id', 'changes')->setLabel('Changes:')->setAttribute(
-                'class',
-                'plain control'
-            )
-        );
+        $this->add(new Changes());
         $this->add(new AgreementFieldset($license));
         $this->add(new Controls());
 
         $inputFilter = new InputFilter('text-exercise-group');
         $inputFilter->add(['name' => 'content', 'required' => true]);
-        $inputFilter->add(['name' => 'changes', 'required' => false, 'filters' => [['name' => 'StripTags']]]);
         $this->setInputFilter($inputFilter);
     }
 }

--- a/packages/public/server/src/module/Entity/src/Entity/Form/TextHintForm.php
+++ b/packages/public/server/src/module/Entity/src/Entity/Form/TextHintForm.php
@@ -22,6 +22,7 @@
  */
 namespace Entity\Form;
 
+use Entity\Form\Element\Changes;
 use Csrf\Form\Element\CsrfToken;
 use Common\Form\Element\EditorState;
 use License\Entity\LicenseInterface;
@@ -41,18 +42,12 @@ class TextHintForm extends Form
         $this->setAttribute('class', 'clearfix');
 
         $this->add((new EditorState('content'))->setLabel('Content:'));
-        $this->add(
-            (new Textarea('changes'))->setAttribute('id', 'changes')->setLabel('Changes:')->setAttribute(
-                'class',
-                'plain control'
-            )
-        );
+        $this->add(new Changes());
         $this->add(new AgreementFieldset($license));
         $this->add(new Controls());
 
         $inputFilter = new InputFilter('text-hint');
         $inputFilter->add(['name' => 'content', 'required' => true]);
-        $inputFilter->add(['name' => 'changes', 'required' => false, 'filters' => [['name' => 'StripTags']]]);
         $this->setInputFilter($inputFilter);
     }
 }

--- a/packages/public/server/src/module/Entity/src/Entity/Form/TextSolutionForm.php
+++ b/packages/public/server/src/module/Entity/src/Entity/Form/TextSolutionForm.php
@@ -22,6 +22,7 @@
  */
 namespace Entity\Form;
 
+use Entity\Form\Element\Changes;
 use Csrf\Form\Element\CsrfToken;
 use Common\Form\Element\EditorState;
 use License\Entity\LicenseInterface;
@@ -41,18 +42,12 @@ class TextSolutionForm extends Form
         $this->setAttribute('class', 'clearfix');
 
         $this->add((new EditorState('content'))->setLabel('Content:'));
-        $this->add(
-            (new Textarea('changes'))->setAttribute('id', 'changes')->setLabel('Changes:')->setAttribute(
-                'class',
-                'plain control'
-            )
-        );
+        $this->add(new Changes());
         $this->add(new AgreementFieldset($license));
         $this->add(new Controls());
 
         $inputFilter = new InputFilter('text-solution');
         $inputFilter->add(['name' => 'content', 'required' => true]);
-        $inputFilter->add(['name' => 'changes', 'required' => false, 'filters' => [['name' => 'StripTags']]]);
         $this->setInputFilter($inputFilter);
     }
 }

--- a/packages/public/server/src/module/Entity/src/Entity/Form/VideoForm.php
+++ b/packages/public/server/src/module/Entity/src/Entity/Form/VideoForm.php
@@ -22,6 +22,7 @@
  */
 namespace Entity\Form;
 
+use Entity\Form\Element\Changes;
 use Csrf\Form\Element\CsrfToken;
 use Common\Form\Element\EditorState;
 use Common\Form\Element\Title;
@@ -49,12 +50,7 @@ class VideoForm extends Form
         $this->add(
             (new EditorState('reasoning'))->setLabel('Reasoning:')->setAttribute('class', 'meta')
         );
-        $this->add(
-            (new Textarea('changes'))->setAttribute('id', 'changes')->setLabel('Changes:')->setAttribute(
-                'class',
-                'plain control'
-            )
-        );
+        $this->add(new Changes());
         $this->add(new AgreementFieldset($license));
         $this->add(new Controls());
 
@@ -81,7 +77,6 @@ class VideoForm extends Form
                 ],
             ]
         );
-        $inputFilter->add(['name' => 'changes', 'required' => false, 'filters' => [['name' => 'StripTags']]]);
         $this->setInputFilter($inputFilter);
     }
 }


### PR DESCRIPTION
Fixes #138 

Maybe a follow-up issue:
We have no visual clue for mandatory fields in neither editor... There is a `title` attribute on the disabled "Save" Button, but it's not really obvious that you have to fill in the changes field.