### PR TITLE
Smaller main image on donation page

### DIFF
--- a/packages/public/server/src/module/Ui/templates/static/spenden.phtml
+++ b/packages/public/server/src/module/Ui/templates/static/spenden.phtml
@@ -100,6 +100,12 @@ echo $this->doctype();
         .partner img {
             width: 80%;
         }
+
+        #main-image {
+            display: block;
+            width: 50%;
+            margin: 0 auto;
+        }
     </style>
 </head>
 <body itemscope itemtype="http://schema.org/WebPage">
@@ -129,11 +135,10 @@ echo $this->doctype();
                             <section>
                                 <div class="r">
                                     <div class="c24">
-                                        <p>
-                                            <img
-                                                src="https://assets.serlo.org/59f762922f93d_c1bea0db3a614ccd33887e6f615b4b60a84e642e.jpg"
-                                                alt="test" title="">
-                                        </p>
+                                        <img
+                                            id="main-image"
+                                            src="https://assets.serlo.org/59f762922f93d_c1bea0db3a614ccd33887e6f615b4b60a84e642e.jpg"
+                                            alt="test" title="">
                                     </div>
                                 </div>
                                 <div class="r">


### PR DESCRIPTION
Small fix because of the following request:
> Kann man das Foto auf der Spendenseite kleiner darstellen, habe das Feedback bekommen dass das iritiert wenn das Spendenformular nicht gleich sichtbar ist auf der Seite?


![grafik](https://user-images.githubusercontent.com/11499926/70706779-ef349080-1cd6-11ea-8ccf-c4daa198d152.png)
