### PR TITLE
Fix style of headings

### DIFF
--- a/packages/public/client/src/main/styles/_content.scss
+++ b/packages/public/client/src/main/styles/_content.scss
@@ -103,7 +103,8 @@
 
 // Typography
 
-#content-layout {
+.r,
+.editor-design {
   h2 {
     font-size: 28px;
   }

--- a/packages/public/server/src/module/Ui/templates/entity/unrevised.twig
+++ b/packages/public/server/src/module/Ui/templates/entity/unrevised.twig
@@ -27,9 +27,9 @@
       <tr>
         <th>{% trans %} Title {% endtrans %}</th>
         <th>{% trans %} Revision {% endtrans %}</th>
+        <th>{% trans %} Changes {% endtrans %}</th>
         <th>{% trans %} Type {% endtrans %}</th>
         <th>{% trans %} Timestamp {% endtrans %}</th>
-        <th>{% trans %} Changes {% endtrans %}</th>
       </tr>
     </thead>
     <tbody>
@@ -47,9 +47,9 @@
                 {{ normalized.getId() }}
               </a>
             </td>
+            <td>{{ revision.get('changes') }}</td>
             <td>{{ normalized.getType() | trans }}</td>
             <td>{{ timeago().render(normalized.getMetadata().getCreationDate()) }}</td>
-            <td>{{ revision.get('changes') }}</td>
           </tr>
         {% endfor %}
       {% endfor %}

--- a/packages/public/server/src/module/Ui/templates/entity/unrevised.twig
+++ b/packages/public/server/src/module/Ui/templates/entity/unrevised.twig
@@ -19,6 +19,7 @@
  # @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
  # @link      https://github.com/serlo-org/serlo.org for the canonical source repository
  #}
+<div class="editor-design">
 {{ pageHeader('Unrevised learning resources').render() }}
 {% for subject, revisionsByEntity in revisionsBySubject %}
   <h2>{{ subject }}</h2>
@@ -56,3 +57,4 @@
     </tbody>
   </table>
 {% endfor %}
+</div>


### PR DESCRIPTION
Reverts https://github.com/serlo/serlo.org/commit/914a1a272b61b96a217dfe29d9d951f8c5fb80e8 since it affects to many headings. This needs to be applied to master before the next deployment.