### PR TITLE
Some english phrases, that are part of the user-output are translated in a weird way into german

### DIFF
--- a/packages/public/server/src/module/Ui/templates/ads/ads.twig
+++ b/packages/public/server/src/module/Ui/templates/ads/ads.twig
@@ -28,7 +28,7 @@
         </a>
         <a href="{{ url('ads/about/editabout') }}" class="btn btn-default pull-left">
             <span class="fa fa-plus"></span>
-            {% trans %} Edit About Horizon {% endtrans %}
+            {% trans %} Edit "About Horizon" {% endtrans %}
         </a>
     {% endif %}
 </div>

--- a/packages/public/server/src/module/Ui/templates/discussion/partials/discuss-button.twig
+++ b/packages/public/server/src/module/Ui/templates/discussion/partials/discuss-button.twig
@@ -21,5 +21,5 @@
  #}
 <a class="discussion-start btn btn-success pull-right"
    href="{{ url('authentication/login', [], {'query': {'ref': form.getAttribute('action') }}) }}">
-    <span class="fa fa-comments"></span> {{ 'Discuss' | trans }}
+    <span class="fa fa-comments"></span> {{ 'Comment' | trans }}
 </a>

--- a/packages/public/server/src/module/Ui/templates/page/update.twig
+++ b/packages/public/server/src/module/Ui/templates/page/update.twig
@@ -19,5 +19,5 @@
  # @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
  # @link      https://github.com/serlo-org/serlo.org for the canonical source repository
  #}
-{{ pageHeader('Update a page' | trans).render() }}
+{{ pageHeader('Update page' | trans).render() }}
 {{ form().render(form) }}

--- a/packages/public/server/src/module/Ui/templates/taxonomy/term/templates/partials/actions.twig
+++ b/packages/public/server/src/module/Ui/templates/taxonomy/term/templates/partials/actions.twig
@@ -27,7 +27,7 @@
 {% if isGranted('taxonomy.term.create', term) %}
     <li>
         <a rel="nofollow" href="{{ url('taxonomy/term/organize', {'term': term.getId()}) }}">
-            <span class="fa fa-th-list"></span> {% trans %} Organize {% endtrans %}
+            <span class="fa fa-th-list"></span> {% trans %} Organize taxonomy {% endtrans %}
         </a>
     </li>
 {% endif %}

--- a/packages/public/server/src/module/Ui/templates/taxonomy/term/templates/partials/groups.twig
+++ b/packages/public/server/src/module/Ui/templates/taxonomy/term/templates/partials/groups.twig
@@ -31,7 +31,7 @@
             <span class="h2 fa-2x fa fa-files-o"></span>
         </div>
         <div class="col-xs-10">
-            <h2>{% trans %} Groups {% endtrans %}</h2>
+            <h2>{% trans %} Exercises {% endtrans %}</h2>
             {% for child in children %}
                 <div class="row">
                     <div class="col-xs-12">

--- a/packages/public/server/src/module/Ui/templates/taxonomy/term/templates/partials/subject-actions.twig
+++ b/packages/public/server/src/module/Ui/templates/taxonomy/term/templates/partials/subject-actions.twig
@@ -26,7 +26,7 @@
 {% if isGranted('taxonomy.term.create', term) %}
     <li>
         <a rel="nofollow" href="{{ url('taxonomy/term/organize', {'term': term.getId()}) }}">
-            <span class="fa fa-th-list"></span> {% trans %} Organize {% endtrans %}
+            <span class="fa fa-th-list"></span> {% trans %} Organize taxonomy {% endtrans %}
         </a>
     </li>
 {% endif %}


### PR DESCRIPTION
For example "Groups" is translated by "Aufgaben", so means in fact "Exercises". This leads to the point that communities in new language-version who translate the platform starting from the english-crowdin translate then "Gruppen" literally. I changed the english user-output, so that if the new phrases (the phrases that I added/changed) are pushed to crowdin the english-output and therefore also the output in all other language-version (translated from the english-output) is more correct.

Following output-phrases have been changed (behind "-->" is the new term that needs to be added to crowdin with the respective german translation)

Groups - Aufgaben --> Exercises - Aufgaben
Update a page - Seite bearbeiten --> Update page - Seite bearbeiten
Edit About Horizon - "Über Horizont" bearbeiten --> Edit "About Horizon" - "Über Horizon" bearbeiten
Discuss - Kommentieren --> Comment - Kommentieren
Manage related links - Zugehörige Inhalte verwalten --> Manage related Content - Zugehörige Inhalte verwalten
Organize - Baumstruktur bearbeiten --> Organize taxonomy - Baumstruktur bearbeiten
unpublished - Unveröffentlichte Blogeinträge --> unpublished blog-posts - Unveröffentliche Blogeinträge

I only changed output-phrases where the literal meaning is different in english and german. 
**Just for completion:** these phrases in Crowdin also have other meanings in the german translation, but I didn't find them (at least in templates/UI)
You have downvoted this comment. - Du hast diesen Kommentar bereits abgewertet. --> nicht gefunden
You have upvoted this comment. - Du hast diesen Kommentar bereits aufgewertet. --> nicht gefunden
applet - GeoGebra Applet --> nicht gefunden

And there the meaning is slightly different (nice to have), but it isn't preasuring: 
Flags - Gemeldete Inhalte
The requested controller was not dispatchable. - Der angeforderte Controller konnte nicht abgesendet werden.
input-string-normalized-match-challenge - Eingabeaufgabe: Wort
multiple-choice-right-answer - richtige Multiple Choice-Antwort
multiple-choice-wrong-answer - falsche Multiple Choice-Antwort
Unarchive discussion - Diskussion wiederherstellen
Current password - Aktuelles Passwort eingeben
New password - Neues Passwort eingeben
Reply - Antwort Abschicken
Password - Passwort eingeben:
Submit - Kommentar abschicken
This site makes heavy use of JavaScript! - Diese Seite benötigt JavaScript!
Type answer - Deine Lösung
Reasoning - Didaktische Überlegungen:
The password entered does not match the confirmation password. Ensure the passwords entered are identical. - Die beiden angegebenen Passwörter stimmen nicht überein.
No Exception available - Keine Ausnahmen verfügbar