### PR TITLE
server: Add scope=row for <th> tags in rows

### DIFF
--- a/packages/public/server/src/module/Ui/templates/entity/repository/history.twig
+++ b/packages/public/server/src/module/Ui/templates/entity/repository/history.twig
@@ -48,7 +48,7 @@
                 </a>)
             </td>
             <td>{{ isCurrent ? '<span class="fa fa-check"></span>' : '' }}</td>
-            <th>{{ revision.get('changes') }}</th>
+            <th scope="row">{{ revision.get('changes') }}</th>
             <td>{{ normalize().toAnchor(revision.getAuthor()) }}</td>
             <td>{{ timeago().render(revision.getTimestamp()) }}</td>
             <td>

--- a/packages/public/server/src/module/Ui/templates/entity/unrevised.twig
+++ b/packages/public/server/src/module/Ui/templates/entity/unrevised.twig
@@ -48,7 +48,7 @@
                 {{ normalized.getId() }}
               </a>
             </td>
-            <td>{{ revision.get('changes') }}</td>
+            <th scope="row">{{ revision.get('changes') }}</th>
             <td>{{ normalized.getType() | trans }}</td>
             <td>{{ timeago().render(normalized.getMetadata().getCreationDate()) }}</td>
           </tr>


### PR DESCRIPTION
Follow up of #154: `scope=row` for a `<th>` defines a heading for a row  (see https://www.w3.org/TR/html52/tabular-data.html#attr-valuedef-scope-row ) -> I have learned something :smile: 