### PR TITLE
server: Fix validation of applet urls (fixes #196)

### DIFF
--- a/packages/public/server/src/module/Entity/src/Entity/Form/AppletForm.php
+++ b/packages/public/server/src/module/Entity/src/Entity/Form/AppletForm.php
@@ -30,7 +30,7 @@ use Common\Form\Element\Title;
 use License\Entity\LicenseInterface;
 use License\Form\AgreementFieldset;
 use Zend\Form\Element\Textarea;
-use Zend\Form\Element\Url;
+use Zend\Form\Element\Text;
 use Zend\Form\Form;
 use Zend\InputFilter\InputFilter;
 use Zend\Validator\Regex;
@@ -46,7 +46,7 @@ class AppletForm extends Form
         $this->setAttribute('class', 'clearfix');
 
         $this->add(new Title());
-        $this->add((new Url('url'))->setAttribute('id', 'url')->setLabel('Applet Url:'));
+        $this->add((new Text('url'))->setAttribute('id', 'url')->setLabel('Applet Url:'));
         $this->add((new EditorState('content'))->setLabel('Description:'));
         $this->add((new EditorState('reasoning'))->setLabel('Reasoning:'));
         $this->add(new Changes());
@@ -69,9 +69,9 @@ class AppletForm extends Form
                     [
                         'name'    => 'Regex',
                         'options' => [
-                            'pattern'  => '~^(https?:\/\/)?(.*?(geogebra\.org\/m\/.+|ggbm\.at\/.+))~',
+                            'pattern'  => '/^(https:\/\/www\.geogebra\.org\/m\/)?[a-zA-Z0-9]+$/',
                             'messages' => [
-                                Regex::NOT_MATCH => 'Applet-URL invalid. Use one of the form geogebra.org/m/id or ggbm.at/id',
+                                Regex::NOT_MATCH => 'Applet-URL invalid. Use the form https://www.geogebra.org/m/<id>',
                             ],
                         ],
                     ],

--- a/packages/public/server/src/module/Entity/test/EntityTest/Form/AppletFormTest.php
+++ b/packages/public/server/src/module/Entity/test/EntityTest/Form/AppletFormTest.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * This file is part of Serlo.org.
+ *
+ * Copyright (c) 2013-2020 Serlo Education e.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @copyright Copyright (c) 2013-2020 Serlo Education e.V.
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://github.com/serlo-org/serlo.org for the canonical source repository
+ */
+namespace EntityTest\Form;
+
+use PHPUnit\Framework\TestCase;
+use Entity\Form\AppletForm;
+use License\Entity\LicenseInterface;
+
+class AppletFormTest extends TestCase
+{
+    private $appletForm;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $license = $this->createMock(LicenseInterface::class);
+        $this->appletForm  = new AppletForm($license);
+    }
+
+    public function testUrlElement()
+    {
+        $urlFilter = $this->appletForm->getInputFilter()->get("url");
+
+        $validUrls = ["https://www.geogebra.org/m/2440601", "2440601", "aAZYthn93", "09azAZ"];
+
+        foreach ($validUrls as $url) {
+            $urlFilter->setValue($url);
+
+            $this->assertTrue($urlFilter->isValid(), sprintf("URL `%s` should be accepted.", $url));
+        }
+
+        $invalidUrls = ["", "http://www.geogebra.org/m/2440601", "https://geogebra.org/m/2440601",
+                        "https://ggbm.at/2440601", "azz aaa", "/123",
+                        "https://www.geogebra.org/m/YdT/", "$5f", ];
+
+        foreach ($invalidUrls as $url) {
+            $urlFilter->setValue($url);
+
+            $this->assertFalse(
+                $urlFilter->isValid(),
+                sprintf("Invalid URL `%s` should not be accepted.", $url)
+            );
+        }
+    }
+}

--- a/packages/public/server/src/module/Renderer/src/Renderer/View/Helper/RendererHelper.php
+++ b/packages/public/server/src/module/Renderer/src/Renderer/View/Helper/RendererHelper.php
@@ -51,6 +51,6 @@ class RendererHelper extends AbstractHelper
     public function toHtml($content)
     {
         $json = json_decode($content, true);
-        return ($json === null) ? htmlspecialchars($content) : $this->getRenderService()->render($content);
+        return $json === null || !is_array($json) ? htmlspecialchars($content) : $this->getRenderService()->render($content) ;
     }
 }

--- a/packages/public/server/src/module/Ui/templates/entity/view/applet.twig
+++ b/packages/public/server/src/module/Ui/templates/entity/view/applet.twig
@@ -23,14 +23,13 @@
 <article>
     <section>
         {% set url = entity.getCurrentRevision().get('url') %}
-        {% if url matches '{^(https?:\\/\\/)?(.*?(geogebra\\.org\\/m\\/.+|ggbm\\.at\\/.+))}' %}
+        {% if url matches '/^(https:\\/\\/www\\.geogebra\\.org\\/m\\/)?[a-zA-Z1-9]+$/' %}
             {% set id =  url | split('/') | last %}
         {% endif %}
         {% if id is defined %}
             {% set src = 'https://www.geogebra.org/material/iframe/id/' ~ id %}
             <p class="embed-responsive embed-responsive-16by9">
-                <iframe class="embed-responsive-item"
-                        src="{{ src }}"></iframe>
+                <iframe class="embed-responsive-item" src="{{ src }}"></iframe>
             </p>
         {% else %}
             <p class="text-center">

--- a/packages/public/server/src/module/Ui/templates/entity/view/applet.twig
+++ b/packages/public/server/src/module/Ui/templates/entity/view/applet.twig
@@ -23,7 +23,7 @@
 <article>
     <section>
         {% set url = entity.getCurrentRevision().get('url') %}
-        {% if url matches '/^(https:\\/\\/www\\.geogebra\\.org\\/m\\/)?[a-zA-Z1-9]+$/' %}
+        {% if url matches '/^(https:\\/\\/www\\.geogebra\\.org\\/m\\/)?[a-zA-Z0-9]+$/' %}
             {% set id =  url | split('/') | last %}
         {% endif %}
         {% if id is defined %}


### PR DESCRIPTION
All occurrences of ggbm.at are replaced at serlo (there is only one version left which is trashed).