### PR TITLE
fix: clean uuid table after purge to avoid inconsistencies

### DIFF
--- a/packages/public/server/src/module/Uuid/src/Uuid/Controller/UuidController.php
+++ b/packages/public/server/src/module/Uuid/src/Uuid/Controller/UuidController.php
@@ -75,6 +75,8 @@ class UuidController extends AbstractActionController
         if ($form->isValid()) {
             $this->getUuidManager()->purgeUuid($this->params('id'));
             $this->getUuidManager()->flush();
+            // cascading deletes might result in dead uuids, so we clear them here
+            $this->getUuidManager()->clearDeadUuids();
             $this->flashMessenger()->addSuccessMessage('The content has been removed.');
         } else {
             $this->flashMessenger()->addErrorMessage('The content could not be removed (validation failed)');

--- a/packages/public/server/src/module/Uuid/src/Uuid/Manager/UuidManagerInterface.php
+++ b/packages/public/server/src/module/Uuid/src/Uuid/Manager/UuidManagerInterface.php
@@ -76,6 +76,11 @@ interface UuidManagerInterface extends Flushable
     public function purgeUuid($id);
 
     /**
+     * @return void
+     */
+    public function clearDeadUuids();
+
+    /**
      * @param int $id
      * @return void
      */


### PR DESCRIPTION
Fixes #229 and closes #193 (after the new purge manager ran once...)

@inyono I want to add some Unit Tests for this before merging, to make sure that the delete logic works as expected.