### PR TITLE
Handle entities without subjects at /entity/unrevised

### DIFF
--- a/packages/public/server/src/module/Common/src/Common/Utils.php
+++ b/packages/public/server/src/module/Common/src/Common/Utils.php
@@ -26,6 +26,6 @@ abstract class Utils
 {
     public static function array_flatmap($map, $array)
     {
-        return array_merge(...array_map($map, $array));
+        return !empty($array) ? array_merge(...array_map($map, $array)) : [];
     }
 }

--- a/packages/public/server/src/module/Common/src/Common/Utils.php
+++ b/packages/public/server/src/module/Common/src/Common/Utils.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * This file is part of Serlo.org.
+ *
+ * Copyright (c) 2013-2020 Serlo Education e.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @copyright Copyright (c) 2013-2020 Serlo Education e.V.
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://github.com/serlo-org/serlo.org for the canonical source repository
+ */
+namespace Common;
+
+abstract class Utils
+{
+    public static function array_flatmap($map, $array)
+    {
+        return array_merge(...array_map($map, $array));
+    }
+}

--- a/packages/public/server/src/module/Common/test/CommonTest/UtilsTest.php
+++ b/packages/public/server/src/module/Common/test/CommonTest/UtilsTest.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * This file is part of Serlo.org.
+ *
+ * Copyright (c) 2013-2020 Serlo Education e.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @copyright Copyright (c) 2013-2020 Serlo Education e.V.
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://github.com/serlo-org/serlo.org for the canonical source repository
+ */
+namespace CommonTest;
+
+use Common\Utils;
+use PHPUnit\Framework\TestCase;
+
+class UtilsTest extends TestCase
+{
+    public function testArrayFlatmap()
+    {
+        $double = function ($x) {
+            return [$x, $x];
+        };
+
+        $this->assertEquals(Utils::array_flatmap($double, [1]), [1, 1]);
+        $this->assertEquals(Utils::array_flatmap($double, [1]), [1, 1]);
+        $this->assertEquals(Utils::array_flatmap($double, [1, 2]), [1, 1, 2, 2]);
+        $this->assertEquals(
+            Utils::array_flatmap($double, ["x", true, 42]),
+            ["x", "x", true, true, 42, 42]
+        );
+    }
+}

--- a/packages/public/server/src/module/Common/test/CommonTest/UtilsTest.php
+++ b/packages/public/server/src/module/Common/test/CommonTest/UtilsTest.php
@@ -33,6 +33,7 @@ class UtilsTest extends TestCase
             return [$x, $x];
         };
 
+        $this->assertEquals(Utils::array_flatmap($double, []), []);
         $this->assertEquals(Utils::array_flatmap($double, [1]), [1, 1]);
         $this->assertEquals(Utils::array_flatmap($double, [1]), [1, 1]);
         $this->assertEquals(Utils::array_flatmap($double, [1, 2]), [1, 1, 2, 2]);

--- a/packages/public/server/src/module/Entity/src/Entity/Controller/EntityController.php
+++ b/packages/public/server/src/module/Entity/src/Entity/Controller/EntityController.php
@@ -81,9 +81,16 @@ class EntityController extends AbstractController
 
         foreach ($revisions as $revision) {
             $entity = $revision->getRepository();
+            $subjectNames = array_map(function ($x) {
+                return $x->getName();
+            }, $entity->getSubjects());
 
-            foreach ($entity->getSubjects() as $subject) {
-                $revisionsBySubject[$subject->getName()][$entity->getId()][] = $revision;
+            if (empty($subjectNames)) {
+                $subjectNames = [$this->getTranslator()->translate("Entities without a subject")];
+            }
+
+            foreach ($subjectNames as $subjectName) {
+                $revisionsBySubject[$subjectName][$entity->getId()][] = $revision;
             }
         }
 

--- a/packages/public/server/src/module/Entity/src/Entity/Entity/Entity.php
+++ b/packages/public/server/src/module/Entity/src/Entity/Entity/Entity.php
@@ -263,13 +263,15 @@ class Entity extends Uuid implements EntityInterface
 
     public function getSubjects()
     {
-        $subjects = !$this->getTaxonomyTerms()->isEmpty()
-                    ? $this->getTaxonomyTerms()->map(function ($term) {
-                        return $term->getSecondLevelAncestor();
-                    })->toArray()
-                    : Utils::array_flatmap(function ($parent) {
-                        return $parent->getSubjects();
-                    }, $this->getParents('link')->toArray());
+        if (!$this->getTaxonomyTerms()->isEmpty()) {
+            $subjects = $this->getTaxonomyTerms()->map(function ($term) {
+                return $term->getSecondLevelAncestor();
+            })->toArray();
+        } else {
+            $subjects = Utils::array_flatmap(function ($parent) {
+                return $parent->getSubjects();
+            }, $this->getParents('link')->toArray());
+        }
 
         return array_unique($subjects, SORT_REGULAR);
     }

--- a/packages/public/server/src/module/Entity/src/Entity/Entity/Entity.php
+++ b/packages/public/server/src/module/Entity/src/Entity/Entity/Entity.php
@@ -36,6 +36,7 @@ use Uuid\Filter\NotTrashedCollectionFilter;
 use Versioning\Entity\RevisionInterface;
 use Versioning\Filter\HasCurrentRevisionCollectionFilter;
 use Zend\Filter\FilterChain;
+use Common\Utils;
 
 /**
  * An entity.
@@ -262,15 +263,11 @@ class Entity extends Uuid implements EntityInterface
 
     public function getSubjects()
     {
-        $flatmap = function ($map, $array) {
-            return array_merge(...array_map($map, $array));
-        };
-
         $subjects = !$this->getTaxonomyTerms()->isEmpty()
                     ? $this->getTaxonomyTerms()->map(function ($term) {
                         return $term->getSecondLevelAncestor();
                     })->toArray()
-                    : $flatmap(function ($parent) {
+                    : Utils::array_flatmap(function ($parent) {
                         return $parent->getSubjects();
                     }, $this->getParents('link')->toArray());
 


### PR DESCRIPTION
Fixes #237 (and also fixes #167 ) by showing revisions of entities without a subject at `/entity/unrevised`:

![2020-01-22-010707_932x512_scrot](https://user-images.githubusercontent.com/1327215/72854087-8ec04800-3cb3-11ea-84fa-2b23d542de5f.png)

This PR is based on #240 which should be merged first.
