### PR TITLE
hotfix: use new slate state converter

### DIFF
--- a/packages/private/legacy-editor-to-editor/__tests-ssr__/splishToEdtr/convertSlate.tsx
+++ b/packages/private/legacy-editor-to-editor/__tests-ssr__/splishToEdtr/convertSlate.tsx
@@ -26,47 +26,94 @@ describe('slate serializer and deserializer work', () => {
   it('can handle empty paragraphs', () => {
     const html = '<p></p>'
 
-    expect(htmlToSlate(html)).toEqual(
-      JSON.parse(
-        '{"object":"value","document":{"object":"document","data":{},"nodes":[{"object":"block","type":"paragraph","nodes":[]}]}}'
-      )
-    )
+    expect(htmlToSlate(html)).toEqual([{ type: 'p', children: [] }])
   })
   it('works with normal text.', () => {
     const html = 'This was created with'
 
-    expect(htmlToSlate(html)).toEqual(
-      JSON.parse(
-        '{"object":"value","document":{"object":"document","data":{},"nodes":[{"object":"block","data":{},"type":"paragraph","nodes":[{"object":"text","leaves":[{"object":"leaf","text":"This was created with"}]}]}]}}'
-      )
-    )
+    expect(htmlToSlate(html)).toEqual([
+      { type: 'p', children: [{ text: 'This was created with' }] }
+    ])
   })
 
   it('works with normal paragraphs and marks.', () => {
     const html = '<p>This was created with <strong>Splish</strong> editor.</p>'
-    expect(htmlToSlate(html)).toEqual(
-      JSON.parse(
-        '{"object":"value","document":{"object":"document","data":{},"nodes":[{"object":"block","type":"paragraph","nodes":[{"object":"text","leaves":[{"object":"leaf","text":"This was created with "}]},{"object":"text","leaves":[{"object":"leaf","text":"Splish","marks":[{"type":"@splish-me/strong"}]}]},{"object":"text","leaves":[{"object":"leaf","text":" editor."}]}]}]}}'
-      )
-    )
+    expect(htmlToSlate(html)).toEqual([
+      {
+        type: 'p',
+        children: [
+          { text: 'This was created with ' },
+          { strong: true, text: 'Splish' },
+          { text: ' editor.' }
+        ]
+      }
+    ])
   })
 
   it('works with list', () => {
     const html = '<ul><li><p>foo</p></li><li><p>bar</p></li></ul>'
-    expect(htmlToSlate(html)).toEqual(
-      JSON.parse(
-        '{"object":"value","document":{"object":"document","data":{},"nodes":[{"object":"block","type":"unordered-list","nodes":[{"object":"block","type":"list-item","nodes":[{"object":"block","type":"list-item-child","nodes":[{"object":"block","type":"paragraph","nodes":[{"object":"text","leaves":[{"object":"leaf","text":"foo"}]}]}]}]},{"object":"block","type":"list-item","nodes":[{"object":"block","type":"list-item-child","nodes":[{"object":"block","type":"paragraph","nodes":[{"object":"text","leaves":[{"object":"leaf","text":"bar"}]}]}]}]}]}]}}'
-      )
-    )
+    expect(htmlToSlate(html)).toEqual([
+      {
+        type: 'unordered-list',
+        children: [
+          {
+            type: 'list-item',
+            children: [
+              {
+                type: 'list-item-child',
+                children: [{ type: 'p', children: [{ text: 'foo' }] }]
+              }
+            ]
+          },
+          {
+            type: 'list-item',
+            children: [
+              {
+                type: 'list-item-child',
+                children: [{ type: 'p', children: [{ text: 'bar' }] }]
+              }
+            ]
+          }
+        ]
+      }
+    ])
   })
 
   it('works with real html from splish slate', () => {
     const html =
       '<p>This was created with <strong>Splish</strong> editor.</p><ul><li><p>foo</p></li><li><p>bar</p></li></ul>'
-    expect(htmlToSlate(html)).toEqual(
-      JSON.parse(
-        '{"object":"value","document":{"object":"document","data":{},"nodes":[{"object":"block","type":"paragraph","nodes":[{"object":"text","leaves":[{"object":"leaf","text":"This was created with "}]},{"object":"text","leaves":[{"object":"leaf","text":"Splish","marks":[{"type":"@splish-me/strong"}]}]},{"object":"text","leaves":[{"object":"leaf","text":" editor."}]}]},{"object":"block","type":"unordered-list","nodes":[{"object":"block","type":"list-item","nodes":[{"object":"block","type":"list-item-child","nodes":[{"object":"block","type":"paragraph","nodes":[{"object":"text","leaves":[{"object":"leaf","text":"foo"}]}]}]}]},{"object":"block","type":"list-item","nodes":[{"object":"block","type":"list-item-child","nodes":[{"object":"block","type":"paragraph","nodes":[{"object":"text","leaves":[{"object":"leaf","text":"bar"}]}]}]}]}]}]}}'
-      )
-    )
+    expect(htmlToSlate(html)).toEqual([
+      {
+        type: 'p',
+        children: [
+          { text: 'This was created with ' },
+          { text: 'Splish', strong: true },
+          { text: ' editor.' }
+        ]
+      },
+      {
+        type: 'unordered-list',
+        children: [
+          {
+            type: 'list-item',
+            children: [
+              {
+                type: 'list-item-child',
+                children: [{ type: 'p', children: [{ text: 'foo' }] }]
+              }
+            ]
+          },
+          {
+            type: 'list-item',
+            children: [
+              {
+                type: 'list-item-child',
+                children: [{ type: 'p', children: [{ text: 'bar' }] }]
+              }
+            ]
+          }
+        ]
+      }
+    ])
   })
 })

--- a/packages/private/legacy-editor-to-editor/src/splishToEdtr/convertSlate.tsx
+++ b/packages/private/legacy-editor-to-editor/src/splishToEdtr/convertSlate.tsx
@@ -21,6 +21,7 @@
  */
 import * as React from 'react'
 import Html, { Rule } from 'slate-html-serializer'
+import { serializer as slateMigrator } from '@edtr-io/plugin-text'
 // @ts-ignore
 import { parseFragment } from 'parse5'
 import { Block, Data, Inline, Mark, Value, ValueJSON } from 'slate'
@@ -117,7 +118,7 @@ export function htmlToSlate(html: string) {
     }
   })
 
-  return deserializer.deserialize(html, { toJSON: true })
+  return slateMigrator.serialize(deserializer.deserialize(html, { toJSON: true }))
 }
 
 type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6


### PR DESCRIPTION
Converting is broken due to state change in #273. This fixes the issue, however we should probably refactor our slate converter soon.