### PR TITLE
Recycle bin: filter by language

### DIFF
--- a/packages/public/server/src/module/Uuid/config/module.config.php
+++ b/packages/public/server/src/module/Uuid/config/module.config.php
@@ -124,7 +124,7 @@ return [
                     ],
                     'setInstanceManager' => [
                         'required' => true,
-                    ]
+                    ],
                 ],
             ],
         ],

--- a/packages/public/server/src/module/Uuid/config/module.config.php
+++ b/packages/public/server/src/module/Uuid/config/module.config.php
@@ -122,6 +122,9 @@ return [
                     'setUuidManager' => [
                         'required' => true,
                     ],
+                    'setInstanceManager' => [
+                        'required' => true,
+                    ]
                 ],
             ],
         ],

--- a/packages/public/server/src/module/Uuid/src/Uuid/Controller/UuidController.php
+++ b/packages/public/server/src/module/Uuid/src/Uuid/Controller/UuidController.php
@@ -24,18 +24,20 @@ namespace Uuid\Controller;
 
 use Csrf\Form\CsrfForm;
 use Uuid\Manager\UuidManagerAwareTrait;
+use Instance\Manager\InstanceManagerAwareTrait;
 use Zend\Mvc\Controller\AbstractActionController;
 use Zend\View\Model\ViewModel;
 use Zend\Form\Form;
 
 class UuidController extends AbstractActionController
 {
-    use UuidManagerAwareTrait;
+    use UuidManagerAwareTrait, InstanceManagerAwareTrait;
 
     public function recycleBinAction()
     {
         $page     = $this->params()->fromQuery('page', 1);
-        $elements = $this->getUuidManager()->findTrashed($page);
+        $instance = $this->getInstanceManager()->getInstanceFromRequest();
+        $elements = $this->getUuidManager()->findTrashed($page, $instance);
         $view     = new ViewModel(['elements' => $elements]);
         $view->setTemplate('uuid/recycle-bin');
         return $view;

--- a/packages/public/server/src/module/Uuid/src/Uuid/Manager/UuidManager.php
+++ b/packages/public/server/src/module/Uuid/src/Uuid/Manager/UuidManager.php
@@ -102,11 +102,18 @@ class UuidManager implements UuidManagerInterface
         $eventLogClassName = $this->getClassResolver()->resolveClassName('Event\Entity\EventLogInterface');
         $eventTypeClassName = $this->getClassResolver()->resolveClassName('Event\Entity\EventInterface');
         $entityTypeClassName = $this->getClassResolver()->resolveClassName('Entity\Entity\EntityInterface');
+        $taxonomyTypeClassName = $this->getClassResolver()->resolveClassName('Taxonomy\Entity\TaxonomyInterface');
+        $taxonomyTermTypeClassName = $this->getClassResolver()->resolveClassName('Taxonomy\Entity\TaxonomyTermInterface');
         $results = $this->objectManager->createQueryBuilder()->select('u')->addSelect('MAX(e.date) AS date')->from($className, 'u')
             ->leftJoin($eventLogClassName, 'e', 'WITH', 'e.uuid = u')
             ->leftJoin($eventTypeClassName, 't', 'WITH', 'e.event = t')
             ->leftJoin($entityTypeClassName, 'ent', 'WITH', 'u.id = ent.id')
-            ->where('u.trashed = :trashed')->andWhere('t.name = :type')->andwhere('ent.instance = :instance OR ent.instance IS NULL')
+            ->leftJoin($taxonomyTermTypeClassName, 'tt', 'WITH', 'u = tt')
+            ->leftJoin($taxonomyTypeClassName, 'tax', 'WITH', 'tt.taxonomy = tax')
+            ->where('u.trashed = :trashed')
+            ->andWhere('t.name = :type')
+            ->andWhere('ent.instance = :instance OR ent.instance IS NULL')
+            ->andWhere('tax.instance = :instance OR tax.instance IS NULL')
             ->groupBy('u')
             ->orderBy('date', 'DESC')
             ->setParameter('trashed', true)->setParameter('type', 'uuid/trash')->setParameter('instance', $instance)

--- a/packages/public/server/src/module/Uuid/src/Uuid/Manager/UuidManager.php
+++ b/packages/public/server/src/module/Uuid/src/Uuid/Manager/UuidManager.php
@@ -96,18 +96,20 @@ class UuidManager implements UuidManagerInterface
     /**
      * {@inheritDoc}
      */
-    public function findTrashed($page)
+    public function findTrashed($page, $instance)
     {
         $className = $this->getClassResolver()->resolveClassName('Uuid\Entity\UuidInterface');
         $eventLogClassName = $this->getClassResolver()->resolveClassName('Event\Entity\EventLogInterface');
         $eventTypeClassName = $this->getClassResolver()->resolveClassName('Event\Entity\EventInterface');
+        $entityTypeClassName = $this->getClassResolver()->resolveClassName('Entity\Entity\EntityInterface');
         $results = $this->objectManager->createQueryBuilder()->select('u')->addSelect('MAX(e.date) AS date')->from($className, 'u')
             ->leftJoin($eventLogClassName, 'e', 'WITH', 'e.uuid = u')
             ->leftJoin($eventTypeClassName, 't', 'WITH', 'e.event = t')
-            ->where('u.trashed = :trashed')->andWhere('t.name = :type')
+            ->leftJoin($entityTypeClassName, 'ent', 'WITH', 'u.id = ent.id')
+            ->where('u.trashed = :trashed')->andWhere('t.name = :type')->andwhere('ent.instance = :instance OR ent.instance IS NULL')
             ->groupBy('u')
             ->orderBy('date', 'DESC')
-            ->setParameter('trashed', true)->setParameter('type', 'uuid/trash')
+            ->setParameter('trashed', true)->setParameter('type', 'uuid/trash')->setParameter('instance', $instance)
             ->getQuery()->getResult();
 
         $purified = [];

--- a/packages/public/server/src/module/Uuid/src/Uuid/Manager/UuidManagerInterface.php
+++ b/packages/public/server/src/module/Uuid/src/Uuid/Manager/UuidManagerInterface.php
@@ -40,9 +40,10 @@ interface UuidManagerInterface extends Flushable
     public function findAll();
 
     /**
-     * Finds trashed Uuids together with the date of the trash event.
+     * Finds trashed Uuids together with the date of the trash event
+     * for a given instance.
      * <code>
-     * $elements = $um->findTrashed($page);
+     * $elements = $um->findTrashed($page, $instance);
      * foreach($elements as $element)
      * {
      *    echo $element["entity"]->getId();
@@ -51,9 +52,10 @@ interface UuidManagerInterface extends Flushable
      * </code>
      *
      * @param int $page
+     * @param int $instance
      * @return Paginator
      */
-    public function findTrashed($page);
+    public function findTrashed($page, $instance);
 
     /**
      * Get an Uuid.


### PR DESCRIPTION
Partially fixes #204.
This will filter entities and revisions by language, won't work for other kinds of objects.

TODO: add taxonomies