### PR TITLE
server: Set Sender header in emails (#366)

### DIFF
--- a/packages/public/server/src/module/Mailman/src/Mailman/Adapter/ZendMailAdapter.php
+++ b/packages/public/server/src/module/Mailman/src/Mailman/Adapter/ZendMailAdapter.php
@@ -79,6 +79,7 @@ class ZendMailAdapter implements AdapterInterface
 
         $bodyPart->setParts([$bodyHtmlMessage, $bodyTextMessage]);
         $message->setFrom($from);
+        $message->setSender($from);
         $message->addTo($to);
         $message->setEncoding("UTF-8");
         $message->setSubject($mail->getSubject());


### PR DESCRIPTION
This PR sets the `Sender` header in send mails. Hopefully it will fix the issue #366.