### PR TITLE
legacy2edtr: Normalize slate state

### DIFF
--- a/packages/private/legacy-editor-to-editor/__tests-ssr__/splishToEdtr/convertSlate.tsx
+++ b/packages/private/legacy-editor-to-editor/__tests-ssr__/splishToEdtr/convertSlate.tsx
@@ -22,7 +22,7 @@
 import { htmlToSlate } from '../../src/splishToEdtr/convertSlate'
 
 describe('slate serializer and deserializer work', () => {
-  it('can handle empty paragraphs', () => {
+  test('can handle empty paragraphs', () => {
     const html = '<p></p>'
 
     expect(htmlToSlate(html)).toEqual({
@@ -34,7 +34,8 @@ describe('slate serializer and deserializer work', () => {
       }
     })
   })
-  it('works with normal text.', () => {
+
+  test('works with normal text.', () => {
     const html = 'This was created with'
 
     expect(htmlToSlate(html)).toEqual({
@@ -60,7 +61,7 @@ describe('slate serializer and deserializer work', () => {
     })
   })
 
-  it('works with normal paragraphs and marks.', () => {
+  test('works with normal paragraphs and marks.', () => {
     const html = '<p>This was created with <strong>Splish</strong> editor.</p>'
     expect(htmlToSlate(html)).toEqual({
       object: 'value',
@@ -91,7 +92,7 @@ describe('slate serializer and deserializer work', () => {
     })
   })
 
-  it('works with list', () => {
+  test('works with list', () => {
     const html = '<ul><li><p>foo</p></li><li><p>bar</p></li></ul>'
     expect(htmlToSlate(html)).toEqual({
       object: 'value',
@@ -161,7 +162,7 @@ describe('slate serializer and deserializer work', () => {
     })
   })
 
-  it('works with real html from splish slate', () => {
+  test('works with real html from splish slate', () => {
     const html =
       '<p>This was created with <strong>Splish</strong> editor.</p><ul><li><p>foo</p></li><li><p>bar</p></li></ul>'
     expect(htmlToSlate(html)).toEqual({
@@ -248,6 +249,32 @@ describe('slate serializer and deserializer work', () => {
                 ]
               }
             ]
+          }
+        ]
+      }
+    })
+  })
+
+  test('normalizes the slate state', () => {
+    const html = '<p>Formula: <katexblock>a^2+b^2=c^2</katexblock></p>'
+
+    expect(htmlToSlate(html)).toEqual({
+      object: 'value',
+      document: {
+        object: 'document',
+        data: {},
+        nodes: [
+          {
+            object: 'block',
+            type: 'paragraph',
+            nodes: [{ object: 'text', text: 'Formula: ', marks: [] }],
+            data: {}
+          },
+          {
+            object: 'block',
+            type: '@splish-me/katex-block',
+            data: { formula: 'a^2+b^2=c^2', inline: false },
+            nodes: [{ object: 'text', text: 'a^2+b^2=c^2', marks: [] }]
           }
         ]
       }

--- a/packages/private/legacy-editor-to-editor/__tests-ssr__/splishToEdtr/normalize-slate.ts
+++ b/packages/private/legacy-editor-to-editor/__tests-ssr__/splishToEdtr/normalize-slate.ts
@@ -1,0 +1,196 @@
+/**
+ * This file is part of Serlo.org.
+ *
+ * Copyright (c) 2013-2020 Serlo Education e.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @copyright Copyright (c) 2013-2020 Serlo Education e.V.
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://github.com/serlo-org/serlo.org for the canonical source repository
+ */
+import {
+  unwrapChildBlocks,
+  normalize
+} from '../../src/splishToEdtr/normalize-slate'
+import { BlockJSON, ValueJSON } from 'slate'
+
+describe('normalizeSlateValue()', () => {
+  test('unwrap child block elements with inline siblings', () => {
+    const input: ValueJSON = {
+      object: 'value',
+      document: {
+        object: 'document',
+        data: {},
+        nodes: [
+          {
+            object: 'block',
+            type: 'paragraph',
+            nodes: [
+              {
+                object: 'block',
+                type: '@splish-me/katex-block',
+                data: { formula: 'a^2+b^2=c^2', inline: false },
+                nodes: [{ object: 'text', text: 'a^2+b^2=c^2', marks: [] }]
+              },
+              { object: 'text', text: ' and ', marks: [] },
+              {
+                object: 'block',
+                type: '@splish-me/katex-block',
+                data: { formula: '\\sqrt{-1}=i', inline: false },
+                nodes: [{ object: 'text', text: '\\sqrt{-1}=i', marks: [] }]
+              }
+            ],
+            data: {}
+          }
+        ]
+      }
+    }
+    const expectedResult: ValueJSON = {
+      object: 'value',
+      document: {
+        object: 'document',
+        data: {},
+        nodes: [
+          {
+            object: 'block',
+            type: '@splish-me/katex-block',
+            data: { formula: 'a^2+b^2=c^2', inline: false },
+            nodes: [{ object: 'text', text: 'a^2+b^2=c^2', marks: [] }]
+          },
+          {
+            object: 'block',
+            type: 'paragraph',
+            nodes: [{ object: 'text', text: ' and ', marks: [] }],
+            data: {}
+          },
+          {
+            object: 'block',
+            type: '@splish-me/katex-block',
+            data: { formula: '\\sqrt{-1}=i', inline: false },
+            nodes: [{ object: 'text', text: '\\sqrt{-1}=i', marks: [] }]
+          }
+        ]
+      }
+    }
+
+    expect(normalize(input)).toEqual(expectedResult)
+  })
+})
+
+describe('unwrapChildBlocks()', () => {
+  describe('unwraps child block elements', () => {
+    test('Example: child block element in the middle', () => {
+      const input: BlockJSON = {
+        object: 'block',
+        type: 'paragraph',
+        nodes: [
+          { object: 'text', text: 'The theorem ', marks: [] },
+          {
+            object: 'block',
+            type: '@splish-me/katex-block',
+            data: { formula: 'a^2+b^2=c^2', inline: false },
+            nodes: [{ object: 'text', text: 'a^2+b^2=c^2', marks: [] }]
+          },
+          { object: 'text', text: ' is very famous.', marks: [] }
+        ],
+        data: {}
+      }
+      const expectedResult = [
+        {
+          object: 'block',
+          type: 'paragraph',
+          nodes: [{ object: 'text', text: 'The theorem ', marks: [] }],
+          data: {}
+        },
+        {
+          object: 'block',
+          type: '@splish-me/katex-block',
+          data: { formula: 'a^2+b^2=c^2', inline: false },
+          nodes: [{ object: 'text', text: 'a^2+b^2=c^2', marks: [] }]
+        },
+        {
+          object: 'block',
+          type: 'paragraph',
+          nodes: [{ object: 'text', text: ' is very famous.', marks: [] }],
+          data: {}
+        }
+      ]
+
+      expect(unwrapChildBlocks(input)).toEqual(expectedResult)
+    })
+
+    test('child block elements as first and last child', () => {
+      const input: BlockJSON = {
+        object: 'block',
+        type: 'paragraph',
+        nodes: [
+          {
+            object: 'block',
+            type: '@splish-me/katex-block',
+            data: { formula: 'a^2+b^2=c^2', inline: false },
+            nodes: [{ object: 'text', text: 'a^2+b^2=c^2', marks: [] }]
+          },
+          { object: 'text', text: ' and ', marks: [] },
+          {
+            object: 'block',
+            type: '@splish-me/katex-block',
+            data: { formula: '\\sqrt{-1}=i', inline: false },
+            nodes: [{ object: 'text', text: '\\sqrt{-1}=i', marks: [] }]
+          }
+        ],
+        data: {}
+      }
+      const expectedResult: BlockJSON[] = [
+        {
+          object: 'block',
+          type: '@splish-me/katex-block',
+          data: { formula: 'a^2+b^2=c^2', inline: false },
+          nodes: [{ object: 'text', text: 'a^2+b^2=c^2', marks: [] }]
+        },
+        {
+          object: 'block',
+          type: 'paragraph',
+          nodes: [{ object: 'text', text: ' and ', marks: [] }],
+          data: {}
+        },
+        {
+          object: 'block',
+          type: '@splish-me/katex-block',
+          data: { formula: '\\sqrt{-1}=i', inline: false },
+          nodes: [{ object: 'text', text: '\\sqrt{-1}=i', marks: [] }]
+        }
+      ]
+
+      expect(unwrapChildBlocks(input)).toEqual(expectedResult)
+    })
+  })
+
+  test('block elements with only inline elements are not changed', () => {
+    const paragraph: BlockJSON = {
+      object: 'block',
+      type: 'paragraph',
+      nodes: [
+        { object: 'text', text: 'Hello ', marks: [] },
+        {
+          object: 'text',
+          text: 'World!',
+          marks: [{ type: '@splish-me/strong' }]
+        }
+      ],
+      data: {}
+    }
+
+    expect(unwrapChildBlocks(paragraph)).toEqual([paragraph])
+  })
+})

--- a/packages/private/legacy-editor-to-editor/src/splishToEdtr/convertSlate.tsx
+++ b/packages/private/legacy-editor-to-editor/src/splishToEdtr/convertSlate.tsx
@@ -24,6 +24,7 @@ import Html, { Rule } from 'slate-html-serializer'
 // @ts-ignore
 import { parseFragment } from 'parse5'
 import { Block, Inline, Mark, Value, ValueJSON } from 'slate'
+import { normalize } from './normalize-slate'
 
 /**
  * This file provides a serializer for the splish slate state to html
@@ -107,7 +108,7 @@ export function htmlToSlate(html: string) {
     }
   })
 
-  return deserializer.deserialize(html, { toJSON: true })
+  return normalize(deserializer.deserialize(html, { toJSON: true }))
 }
 
 type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6

--- a/packages/private/legacy-editor-to-editor/src/splishToEdtr/normalize-slate.ts
+++ b/packages/private/legacy-editor-to-editor/src/splishToEdtr/normalize-slate.ts
@@ -1,0 +1,82 @@
+/**
+ * This file is part of Serlo.org.
+ *
+ * Copyright (c) 2013-2020 Serlo Education e.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @copyright Copyright (c) 2013-2020 Serlo Education e.V.
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://github.com/serlo-org/serlo.org for the canonical source repository
+ */
+import * as R from 'ramda'
+import {
+  BlockJSON,
+  NodeJSON,
+  ValueJSON,
+  DocumentJSON,
+  InlineJSON,
+  TextJSON
+} from 'slate'
+
+export function normalize(value: ValueJSON): ValueJSON {
+  return {
+    ...value,
+    document: value.document ? normalizeNode(value.document)[0] : undefined
+  }
+}
+
+function normalizeNode<A extends NodeJSON>(node: A): A[] {
+  if (isBlock(node)) {
+    if (node?.nodes?.some(isInline) && node?.nodes?.some(isBlock)) {
+      // @ts-ignore
+      return R.chain(normalizeNode, unwrapChildBlocks(node))
+    } else {
+      return [{ ...node, nodes: R.chain(normalizeNode, node.nodes ?? []) }]
+    }
+  } else if (isDocument(node)) {
+    return [{ ...node, nodes: R.chain(normalizeNode, node.nodes ?? []) }]
+  } else {
+    return [node]
+  }
+}
+
+export function unwrapChildBlocks(node: BlockJSON): BlockJSON[] {
+  if (node.nodes === undefined) return [node]
+
+  const result: BlockJSON[] = []
+  let nodesToInspect = node.nodes
+
+  while (nodesToInspect.length > 0) {
+    const [inlineNodes, tailNodes] = R.splitWhen(isBlock, nodesToInspect)
+
+    if (inlineNodes.length > 0) result.push({ ...node, nodes: inlineNodes })
+    if (tailNodes.length > 0) result.push(tailNodes[0] as BlockJSON)
+
+    nodesToInspect = tailNodes.slice(1)
+  }
+
+  return result
+}
+
+function isBlock(node: NodeJSON): node is BlockJSON {
+  return node?.object === 'block'
+}
+
+function isDocument(node: NodeJSON): node is DocumentJSON {
+  return node?.object === 'document'
+}
+
+function isInline(node: NodeJSON): node is InlineJSON | TextJSON {
+  return node?.object === 'inline' || node?.object === 'text'
+}


### PR DESCRIPTION
Normalizes the slate state in the converter for the legacy editor (it unwraps block elements next to inline siblings). It fixes #392 