### PR TITLE
server: Remove legacy ory code from templates

### DIFF
--- a/packages/public/server/src/module/Ui/templates/entity/page/course.twig
+++ b/packages/public/server/src/module/Ui/templates/entity/page/course.twig
@@ -24,9 +24,7 @@
 {% include 'entity/page/partials/placeholders' %}
 <div itemscope itemtype="http://schema.org/Article">
     <div class="page-header">
-        <div class="editable">
-            <h1><span itemprop="name">{{ title }}</span></h1>
-        </div>
+        <h1><span itemprop="name">{{ title }}</span></h1>
         {% include 'entity/view/partials/actions/big' %}
     </div>
     <div itemprop="articleBody">

--- a/packages/public/server/src/module/Ui/templates/entity/page/video.twig
+++ b/packages/public/server/src/module/Ui/templates/entity/page/video.twig
@@ -30,9 +30,7 @@
         {% do placeholder('isLeaf').set(true) %}
         {% do placeholder('breadcrumbs').set('<li><span>' ~ title ~ '</span></li>') %}
         {% if not layout().usingAPI %}
-          <div class="editable">
-              <h1 itemprop="name">{{ title }}</h1>
-          </div>
+          <h1 itemprop="name">{{ title }}</h1>
         {% endif %}
         {% include 'entity/view/partials/actions/big' %}
     </div>

--- a/packages/public/server/src/module/Ui/templates/entity/repository/compare-revision.twig
+++ b/packages/public/server/src/module/Ui/templates/entity/repository/compare-revision.twig
@@ -65,22 +65,10 @@
                             </div>
                         </div>
                         <div class="tab-pane fade" id="old{{ field.getName() }}">
-                            {% if compareFieldIsLegacy %}
-                                {{ renderer().toHtml(compareRevision.get(field.getName())) }}
-                            {% else %}
-                                <div class="editable" data-edit-type="ory">
-                                    {{ renderer().toHtml(compareRevision.get(field.getName())) }}
-                                </div>
-                            {% endif %}
+                          {{ renderer().toHtml(compareRevision.get(field.getName())) }}
                         </div>
                         <div class="tab-pane fade in active" id="preview{{ field.getName() }}">
-                            {% if fieldIsLegacy %}
-                                {{ renderer().toHtml(field.getValue()) }}
-                            {% else %}
-                                <div class="editable" data-edit-type="ory">
-                                    {{ renderer().toHtml(field.getValue()) }}
-                                </div>
-                            {% endif %}
+                          {{ renderer().toHtml(field.getValue()) }}
                         </div>
                     </div>
                 </div>

--- a/packages/public/server/src/module/Ui/templates/entity/view/article.twig
+++ b/packages/public/server/src/module/Ui/templates/entity/view/article.twig
@@ -23,12 +23,11 @@
 {% set revision = entity.getCurrentRevision() %}
 {% set content = renderer().toHtml(revision.get('content')) %}
 <article>
-    <section class="editable">
+    <section>
         {{ content }}
     </section>
 
     {% include 'entity/view/partials/license' %}
-
 
 </article>
 {% set discussions %}

--- a/packages/public/server/src/module/Ui/templates/entity/view/course-page.twig
+++ b/packages/public/server/src/module/Ui/templates/entity/view/course-page.twig
@@ -44,15 +44,11 @@
 
 <div class="row">
     <div class="col-xs-12">
-        <h1 class="heading-content editable">
-            {{ revision.get('title') }}
-        </h1>
+        <h1 class="heading-content">{{ revision.get('title') }}</h1>
     </div>
 </div>
 <div class="row">
-    <div class="col-xs-12 editable">
-        {{ content }}
-    </div>
+    <div class="col-xs-12">{{ content }}</div>
 </div>
 
 {% if next is not null %}

--- a/packages/public/server/src/module/Ui/templates/entity/view/event.twig
+++ b/packages/public/server/src/module/Ui/templates/entity/view/event.twig
@@ -23,7 +23,7 @@
 {% set revision = entity.getCurrentRevision() %}
 {% set content = renderer().toHtml(revision.get('content')) %}
 <article itemprop="description">
-    <section class="editable">
+    <section>
         {{ content }}
     </section>
 </article>

--- a/packages/public/server/src/module/Ui/templates/entity/view/partials/input-challenge.twig
+++ b/packages/public/server/src/module/Ui/templates/entity/view/partials/input-challenge.twig
@@ -36,7 +36,7 @@
                data-wrong-inputs="{{ wrongInputs | escape('html_attr') }}">
     </div>
     <div class="row">
-        <div class="col-xs-12 input-challenge-feedback pull-right collapse editable"></div>
+        <div class="col-xs-12 input-challenge-feedback pull-right collapse"></div>
     </div>
     <div class="input-challenge-solution">
         {% if showSolution %}

--- a/packages/public/server/src/module/Ui/templates/entity/view/partials/math-puzzle.twig
+++ b/packages/public/server/src/module/Ui/templates/entity/view/partials/math-puzzle.twig
@@ -28,7 +28,7 @@
     <section class="row">
         <div class="col-xs-12 col-sm-11">
             <div class="math-puzzle" data-source="{{ source }}">
-                <div class="exercise editable">
+                <div class="exercise">
                     {{ renderer().toHtml(revision.get('content')) | raw }}
                 </div>
             </div>

--- a/packages/public/server/src/module/Ui/templates/entity/view/partials/multiple-choice-answer.twig
+++ b/packages/public/server/src/module/Ui/templates/entity/view/partials/multiple-choice-answer.twig
@@ -31,14 +31,14 @@
 {% set feedback = feedbackContent ? feedbackContent : defaultFeedback %}
 
 <div class="col-sm-3 multiple-choice-answer-group" itemprop="articleBody">
-    <button class="btn multiple-choice-answer-content button-default editable"
+    <button class="btn multiple-choice-answer-content button-default"
             name="multiple-choice-answer-choice-{{  parent.getID() }}"
             data-correct="{{ right }}">
         {{ displayContent | raw }}
     </button>
     {% if not right %}
         <div class="multiple-choice-answer-feedback collapse">
-            <div class="alert alert-warning editable">
+            <div class="alert alert-warning">
                 {{ feedback | raw }}
             </div>
         </div>

--- a/packages/public/server/src/module/Ui/templates/entity/view/partials/single-choice-answer.twig
+++ b/packages/public/server/src/module/Ui/templates/entity/view/partials/single-choice-answer.twig
@@ -31,14 +31,14 @@
 {% set feedback = feedbackContent ? feedbackContent : defaultFeedback %}
 
 <div class="col-sm-3 single-choice-answer-group" itemprop="articleBody">
-    <button class="btn single-choice-answer-content button-default editable"
+    <button class="btn single-choice-answer-content button-default"
             name="single-choice-answer-choice-{{  parent.getID() }}"
             data-correct="{{ right }}">
         {{ displayContent | raw }}
     </button>
     {% if not right %}
     <div class="single-choice-answer-feedback collapse">
-        <div class="alert alert-warning editable">
+        <div class="alert alert-warning">
             {{ feedback | raw }}
         </div>
     </div>

--- a/packages/public/server/src/module/Ui/templates/entity/view/partials/text-exercise.twig
+++ b/packages/public/server/src/module/Ui/templates/entity/view/partials/text-exercise.twig
@@ -33,7 +33,7 @@
 {% set inputChallenge = inputChallenge().fetchInput(entity) %}
 <article class="text-exercise  {{ multipleChoices|length>4 or singleChoices|length>4 ? 'extended' }}" itemscope itemtype="http://schema.org/Article">
     <section class="row">
-        <div class="col-xs-12 col-sm-11 editable" itemprop="articleBody">
+        <div class="col-xs-12 col-sm-11" itemprop="articleBody">
             {{ renderer().toHtml(revision.get('content')) | raw }}
         </div>
         <div class="hidden-xs col-sm-1" style="padding:0">

--- a/packages/public/server/src/module/Ui/templates/entity/view/text-exercise-group.twig
+++ b/packages/public/server/src/module/Ui/templates/entity/view/text-exercise-group.twig
@@ -22,7 +22,7 @@
 {% set title = 'text-exercise-group' | trans %}
 <article class="exercisegroup">
     <section class="row" style="margin-right:0px">
-        <div class="col-xs-12 col-sm-11 editable" itemprop="articleBody">
+        <div class="col-xs-12 col-sm-11" itemprop="articleBody">
             {{ renderer().toHtml(entity.getCurrentRevision().get('content')) }}
         </div>
         <div class="col-xs-hidden col-sm-1" style="padding:0">

--- a/packages/public/server/src/module/Ui/templates/entity/view/text-solution.twig
+++ b/packages/public/server/src/module/Ui/templates/entity/view/text-solution.twig
@@ -32,7 +32,7 @@
                     </div>
                 </div>
                 <div class="row">
-                    <div class="col-xs-12 editable">
+                    <div class="col-xs-12">
                         {% if revision %}
                             {{ renderer().toHtml(revision.get('content')) | raw }}
                         {% elseif not entity.getHead() %}

--- a/packages/public/server/src/module/Ui/templates/layout/1-col.phtml
+++ b/packages/public/server/src/module/Ui/templates/layout/1-col.phtml
@@ -54,7 +54,6 @@ $pageClass = join(' ', $pageClasses);
             <?php echo $this->partial('layout/partials/notifications'); ?>
             <?php echo $this->partial('layout/partials/main'); ?>
         </div>
-        <div id="ory-editor-control-popup" style="display:none;"></div>
         <?php echo $this->partial('layout/partials/banner'); ?>
         <?php echo $this->partial('layout/partials/discussions'); ?>
         <?php echo $this->partial('layout/partials/horizon'); ?>

--- a/packages/public/server/src/module/Ui/templates/layout/2-col.phtml
+++ b/packages/public/server/src/module/Ui/templates/layout/2-col.phtml
@@ -64,7 +64,6 @@ $pageClass = join(' ', $pageClasses);
                 <?php echo $this->partial('layout/partials/notifications'); ?>
                 <?php echo $this->partial('layout/partials/main'); ?>
             </div>
-            <div id="ory-editor-control-popup" style="display:none;"></div>
             <?php echo $this->partial('layout/partials/banner'); ?>
             <?php echo $this->partial('layout/partials/discussions'); ?>
             <?php echo $this->partial('layout/partials/horizon'); ?>

--- a/packages/public/server/src/module/Ui/templates/layout/3-col.phtml
+++ b/packages/public/server/src/module/Ui/templates/layout/3-col.phtml
@@ -72,7 +72,6 @@ $pageClass = join(' ', $pageClasses);
                 <?php echo $this->partial('layout/partials/notifications'); ?>
                 <?php echo $this->partial('layout/partials/main'); ?>
             </div>
-            <div id="ory-editor-control-popup" style="display:none;"></div>
             <?php echo $this->partial('layout/partials/banner'); ?>
             <?php echo $this->partial('layout/partials/discussions'); ?>
             <?php $isCourse = $this->registry()->get('rnav-is-course'); ?>

--- a/packages/public/server/src/module/Ui/templates/layout/partials/footer.phtml
+++ b/packages/public/server/src/module/Ui/templates/layout/partials/footer.phtml
@@ -112,20 +112,4 @@ $rightNavigation = processNavigation($this->navigation('footer_right_navigation'
     </footer>
 <?php endif; ?>
 
-<div id="controls"></div>
-
-<div id="loading" style="display:none;">
-    <div class="modal fade in is-block" tabindex="-1" role="dialog" aria-labelledby="" aria-hidden="false">
-        <div class="modal-dialog">
-            <div class="modal-content" style="text-align:center;">
-                <h4 class="modal-title">
-                    <?php echo $this->translate('Loading'); ?>
-                </h4>
-                <img src="https://assets.serlo.org/5b9247a7dedec_362184da537da5821203cbd48f7b632e0f4c6a05/loading.gif">
-            </div>
-        </div>
-    </div>
-    <div class="modal-backdrop fade in"></div>
-</div>
-
 <?php echo $this->partial('layout/partials/scripts'); ?>

--- a/packages/public/server/src/module/Ui/templates/layout/partials/header.phtml
+++ b/packages/public/server/src/module/Ui/templates/layout/partials/header.phtml
@@ -92,19 +92,6 @@
                     </div>
                     <?php echo $this->partial('layout/partials/search'); ?>
                 </div>
-                <div id="ory-editor-toolbar" style="display: none;">
-                    <div class="subject-nav-center">
-                        <div class="pull-right controls">
-                            <div class="btn-group">
-                                <button id="ory-editor-save" class="btn btn-success"><span class="fa fa-save"></span> Save</button>
-                                <button id="ory-editor-abort" class="btn btn-danger"><span class="fa fa-times"></span> Cancel</button>
-                            </div>
-                        </div>
-                        <div id="ory-editor-toolbar-functions">
-                            <!--More functions of the Editor...-->
-                        </div>
-                    </div>
-                </div>
             </nav>
         <?php endif; ?>
         <?php if (!$this->layout()->fullWidth): ?>

--- a/packages/public/server/src/module/Ui/templates/layout/partials/right-sidebar.phtml
+++ b/packages/public/server/src/module/Ui/templates/layout/partials/right-sidebar.phtml
@@ -34,9 +34,4 @@
         </div>
     </aside>
     <?php endif;?>
-    <aside class="side-element side-context">
-        <div id="ory-editor-meta-data-wrapper" style="display:none;">
-            <div id="ory-editor-meta-data"></div>
-        </div>
-    </aside>
 <?php endif;?>

--- a/packages/public/server/src/module/Ui/templates/page/partials/head.twig
+++ b/packages/public/server/src/module/Ui/templates/page/partials/head.twig
@@ -21,7 +21,7 @@
  #}
 {% do normalize().headMeta(revision).headTitle(revision) %}
 {% set title = revision.getTitle() %}
-<div class="page-header editable">
+<div class="page-header">
     {% set controls = include('page/partials/controls') %}
     {% do placeholder('controls').set(controls) %}
     {% do placeholder('breadcrumbs').set('<li><span>' ~ title ~ '</span></li>') %}

--- a/packages/public/server/src/module/Ui/templates/page/revision/view.twig
+++ b/packages/public/server/src/module/Ui/templates/page/revision/view.twig
@@ -25,7 +25,7 @@
         <header>
             {% include 'page/partials/head' %}
         </header>
-        <section itemprop="articleBody" class="editable">
+        <section itemprop="articleBody">
             {{ renderer().toHtml(revision.getContent()) }}
         </section>
     </article>


### PR DESCRIPTION
Code were included in https://github.com/serlo/athene2/commit/717e2373c027bfa4a35e4dd73aa28dd7bee02f44 but can be removed.