### PR TITLE
server: Fix math subject name of Spanish tenant

### DIFF
--- a/packages/public/server/src/module/Subject/config/instances.config.php
+++ b/packages/public/server/src/module/Subject/config/instances.config.php
@@ -310,7 +310,7 @@ return [
                         'applet',
                     ],
                 ],
-                'Matemáticas' => [
+                'matemáticas' => [
                     'allowed_taxonomies' => ['topic', 'locale'],
                     'allowed_entities' => [
                         'article',


### PR DESCRIPTION
Fixes error at a site like https://es.serlo.org/matem%C3%A1ticas/n%C3%BAmeros-y-medidas/divisores-y-n%C3%BAmeros-primos (for authenticated user) which results in error message `An exception has been thrown during the rendering of a template ("Subject "matemáticas" unknown.") in "taxonomy/term/templates/partials/actions" at line 47`