### PR TITLE
Quickfix: make viewbox larger for spanish text

### DIFF
--- a/packages/public/server/src/module/Ui/templates/layout/default/about-serlo.phtml
+++ b/packages/public/server/src/module/Ui/templates/layout/default/about-serlo.phtml
@@ -33,10 +33,10 @@
     id="Ebene_1"
     x="0px"
     y="0px"
-    viewBox="148 -89 426.61067 282.94318"
+    viewBox="138 -89 446.61067 282.94318"
     xml:space="preserve"
     inkscape:version="0.92.3 (2405546, 2018-03-11)"
-    width="426.61066"
+    width="446.61066"
     height="282.94318"><metadata
         id="metadata61"><rdf:RDF><cc:Work
                 rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type


### PR DESCRIPTION
fixes #446 
Problem is: the viewBox cuts off the spanish text, so I increased the width of the svg box by 10 to left and right.
Maybe there's also a way to automatically set the viewBox, but this is a quick fix for the issue, until a language has even longer phrases :D