### PR TITLE
api: Add routes for accessing active community

### DIFF
--- a/packages/public/server/README.md
+++ b/packages/public/server/README.md
@@ -106,3 +106,11 @@ Covers some best practices that new code should comply to.
   There is a possibility to define taxonomy terms in which each edit shall be automatically reviewed.
   This is useful when you want for example set up a sandbox area in which all edits shall be automatically online.
   To archieve this you need to set the configuration variable `autoreview_taxonomy_term_ids` to the list of those taxonomy term ids.
+- **Timestamp for calculating the active community:**
+  There are two routes `/api/user/active-authors` and `/api/user/active-reviewers` for accessing the active authors or active reviewers which are defined by 10 edits / reviews in the last 90 days.
+  However in the local database there are no edits in the last years.
+  Thus when we calculate the active community in the local development environment both events would be empty.
+  So we introduced the configuration `mysql_timestamp_for_active_community`.
+  It is the mysql endpoint of the time frame in which the active community is calculated.
+  For development you can set it to something like `Date("2014-01-01")`.
+  In production you can omit this value since `CURDATE()` is the default value.

--- a/packages/public/server/src/config/autoload/global.php
+++ b/packages/public/server/src/config/autoload/global.php
@@ -157,5 +157,9 @@ return [
 
     // Timestamp which is used for calculating the active community
     // Use `CURDATE()` for production system
-    'mysql_timestamp_for_active_community' => $mysql_timestamp_for_active_community,
+    'mysql_timestamp_for_active_community' => isset(
+        $mysql_timestamp_for_active_community
+    )
+        ? $mysql_timestamp_for_active_community
+        : 'CURDATE()',
 ];

--- a/packages/public/server/src/config/autoload/global.php
+++ b/packages/public/server/src/config/autoload/global.php
@@ -154,4 +154,8 @@ return [
 
     // List of taxonomy term ids in which each edit shall be autoreviewed
     'autoreview_taxonomy_term_ids' => $autoreview_taxonomy_term_ids,
+
+    // Timestamp which is used for calculating the active community
+    // Use `CURDATE()` for production system
+    'mysql_timestamp_for_active_community' => $mysql_timestamp_for_active_community,
 ];

--- a/packages/public/server/src/config/definitions.local.php
+++ b/packages/public/server/src/config/definitions.local.php
@@ -59,3 +59,5 @@ $upload_secret = 'secret';
 $mock_email = true;
 
 $autoreview_taxonomy_term_ids = [35607];
+
+$mysql_timestamp_for_active_community = 'DATE("2014-01-01")';

--- a/packages/public/server/src/module/Api/config/module.config.php
+++ b/packages/public/server/src/module/Api/config/module.config.php
@@ -27,6 +27,7 @@ use Api\Controller\ApiController;
 use Api\Controller\CacheApiController;
 use Api\Controller\NavigationApiController;
 use Api\Controller\NotificationApiController;
+use Api\Controller\UserApiController;
 use Api\Factory\AliasManagerListenerFactory;
 use Api\Factory\ApiControllerFactory;
 use Api\Factory\ApiManagerFactory;
@@ -42,6 +43,7 @@ use Api\Factory\NotificationManagerListenerFactory;
 use Api\Factory\PageManagerListenerFactory;
 use Api\Factory\RepositoryManagerListenerFactory;
 use Api\Factory\TaxonomyManagerListenerFactory;
+use Api\Factory\UserApiControllerFactory;
 use Api\Factory\UserManagerListenerFactory;
 use Api\Factory\UuidManagerListenerFactory;
 use Api\Listener\AliasManagerListener;
@@ -66,6 +68,7 @@ return [
                 NavigationApiControllerFactory::class,
             NotificationApiController::class =>
                 NotificationApiControllerFactory::class,
+            UserApiController::class => UserApiControllerFactory::class,
         ],
     ],
     'service_manager' => [
@@ -101,6 +104,16 @@ return [
                     ],
                 ],
                 'child_routes' => [
+                    'active-authors' => [
+                        'type' => 'segment',
+                        'options' => [
+                            'route' => '/user/active-authors',
+                            'defaults' => [
+                                'controller' => UserApiController::class,
+                                'action' => 'getActiveAuthorIds',
+                            ],
+                        ],
+                    ],
                     'alias' => [
                         'type' => 'Common\Router\Slashable',
                         'options' => [

--- a/packages/public/server/src/module/Api/config/module.config.php
+++ b/packages/public/server/src/module/Api/config/module.config.php
@@ -114,6 +114,16 @@ return [
                             ],
                         ],
                     ],
+                    'active-reviewers' => [
+                        'type' => 'segment',
+                        'options' => [
+                            'route' => '/user/active-reviewers',
+                            'defaults' => [
+                                'controller' => UserApiController::class,
+                                'action' => 'getActiveReviewerIds',
+                            ],
+                        ],
+                    ],
                     'alias' => [
                         'type' => 'Common\Router\Slashable',
                         'options' => [

--- a/packages/public/server/src/module/Api/src/Controller/UserApiController.php
+++ b/packages/public/server/src/module/Api/src/Controller/UserApiController.php
@@ -40,4 +40,9 @@ class UserApiController extends AbstractApiController
     {
         return new JsonModel($this->userManager->getActiveAuthorIds());
     }
+
+    public function getActiveReviewerIdsAction()
+    {
+        return new JsonModel($this->userManager->getActiveReviewerIds());
+    }
 }

--- a/packages/public/server/src/module/Api/src/Controller/UserApiController.php
+++ b/packages/public/server/src/module/Api/src/Controller/UserApiController.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * This file is part of Serlo.org.
+ *
+ * Copyright (c) 2013-2020 Serlo Education e.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @copyright Copyright (c) 2013-2020 Serlo Education e.V.
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://github.com/serlo-org/serlo.org for the canonical source repository
+ */
+
+namespace Api\Controller;
+
+use Api\Service\AuthorizationService;
+use User\Manager\UserManagerAwareTrait;
+use Zend\View\Model\JsonModel;
+
+class UserApiController extends AbstractApiController
+{
+    use UserManagerAwareTrait;
+
+    public function __construct(AuthorizationService $authorizationService)
+    {
+        parent::__construct($authorizationService);
+    }
+
+    public function getActiveAuthorIdsAction()
+    {
+        return new JsonModel($this->userManager->getActiveAuthorIds());
+    }
+}

--- a/packages/public/server/src/module/Api/src/Factory/UserApiControllerFactory.php
+++ b/packages/public/server/src/module/Api/src/Factory/UserApiControllerFactory.php
@@ -27,6 +27,7 @@ use Api\Controller\UserApiController;
 use Api\Service\AuthorizationService;
 use Common\Factory\AbstractControllerFactory;
 use User\Manager\UserManager;
+use User\Manager\UserManagerInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
 class UserApiControllerFactory extends AbstractControllerFactory
@@ -39,7 +40,7 @@ class UserApiControllerFactory extends AbstractControllerFactory
         );
         $controller = new UserApiController($authorizationService);
 
-        /** @var UserManager $userManager */
+        /** @var UserManagerInterface $userManager */
         $userManager = $serviceManager->get(UserManager::class);
         $controller->setUserManager($userManager);
 

--- a/packages/public/server/src/module/Api/src/Factory/UserApiControllerFactory.php
+++ b/packages/public/server/src/module/Api/src/Factory/UserApiControllerFactory.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * This file is part of Serlo.org.
+ *
+ * Copyright (c) 2013-2020 Serlo Education e.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @copyright Copyright (c) 2013-2020 Serlo Education e.V.
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://github.com/serlo-org/serlo.org for the canonical source repository
+ */
+
+namespace Api\Factory;
+
+use Api\Controller\UserApiController;
+use Api\Service\AuthorizationService;
+use Common\Factory\AbstractControllerFactory;
+use User\Manager\UserManager;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class UserApiControllerFactory extends AbstractControllerFactory
+{
+    protected function createController(ServiceLocatorInterface $serviceManager)
+    {
+        /** @var AuthorizationService $authorizationService */
+        $authorizationService = $serviceManager->get(
+            AuthorizationService::class
+        );
+        $controller = new UserApiController($authorizationService);
+
+        /** @var UserManager $userManager */
+        $userManager = $serviceManager->get(UserManager::class);
+        $controller->setUserManager($userManager);
+
+        return $controller;
+    }
+}

--- a/packages/public/server/src/module/Api/test/Controller/ApiControllerTest.php
+++ b/packages/public/server/src/module/Api/test/Controller/ApiControllerTest.php
@@ -33,18 +33,32 @@ class ApiControllerTest extends AbstractHttpControllerTestCase
 
     public function testActiveAuthors()
     {
+        $this->mockUserManager('getActiveAuthorIds', [1, 10]);
+
+        $this->dispatch('/api/user/active-authors');
+        $this->assertControllerName(UserApiController::class);
+        $this->assertJsonResponse([1, 10], $this->getResponse());
+    }
+
+    public function testActiveReviewers()
+    {
+        $this->mockUserManager('getActiveReviewerIds', [1, 10]);
+
+        $this->dispatch('/api/user/active-reviewers');
+        $this->assertControllerName(UserApiController::class);
+        $this->assertJsonResponse([1, 10], $this->getResponse());
+    }
+
+    protected function mockUserManager(string $method, array $idList)
+    {
         $userManager = $this->getMockBuilder(UserManager::class)
-            ->setMethods(['getActiveAuthorIds'])
+            ->setMethods([$method])
             ->getMock();
-        $userManager->method('getActiveAuthorIds')->willReturn([1, 10]);
+        $userManager->method($method)->willReturn($idList);
 
         $this->getApplicationServiceLocator()->setService(
             UserManager::class,
             $userManager
         );
-
-        $this->dispatch('/api/user/active-authors');
-        $this->assertControllerName(UserApiController::class);
-        $this->assertJsonResponse([1, 10], $this->getResponse());
     }
 }

--- a/packages/public/server/src/module/Api/test/Controller/ApiControllerTest.php
+++ b/packages/public/server/src/module/Api/test/Controller/ApiControllerTest.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * This file is part of Serlo.org.
+ *
+ * Copyright (c) 2013-2020 Serlo Education e.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @copyright Copyright (c) 2013-2020 Serlo Education e.V.
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://github.com/serlo-org/serlo.org for the canonical source repository
+ */
+
+namespace ApiTest\Controller;
+
+use Api\Controller\UserApiController;
+use AtheneTest\TestCase\AbstractHttpControllerTestCase;
+use User\Manager\UserManager;
+
+class ApiControllerTest extends AbstractHttpControllerTestCase
+{
+    protected $modules = ['ApiTest'];
+
+    public function testActiveAuthors()
+    {
+        $userManager = $this->getMockBuilder(UserManager::class)
+            ->setMethods(['getActiveAuthorIds'])
+            ->getMock();
+        $userManager->method('getActiveAuthorIds')->willReturn([1, 10]);
+
+        $this->getApplicationServiceLocator()->setService(
+            UserManager::class,
+            $userManager
+        );
+
+        $this->dispatch('/api/user/active-authors');
+        $this->assertControllerName(UserApiController::class);
+        $this->assertJsonResponse([1, 10], $this->getResponse());
+    }
+}

--- a/packages/public/server/src/module/Api/test/Controller/NavigationApiControllerTest.php
+++ b/packages/public/server/src/module/Api/test/Controller/NavigationApiControllerTest.php
@@ -25,24 +25,14 @@ namespace ApiTest\Controller;
 
 use Api\Controller\NavigationApiController;
 use AtheneTest\TestCase\AbstractHttpControllerTestCase;
-use InstanceTest\Stub\Manager\InstanceManagerStubAwareTrait;
 use Navigation\Exception\ContainerNotFoundException;
 use Navigation\Service\NavigationService;
 use PHPUnit_Framework_MockObject_Stub_Return;
-use Zend\Http\Response;
 use Zend\Stdlib\ResponseInterface;
 
 class NavigationApiControllerTest extends AbstractHttpControllerTestCase
 {
-    use InstanceManagerStubAwareTrait;
-
     protected $modules = ['ApiTest'];
-
-    public function setUp()
-    {
-        parent::setUp();
-        $this->setUpInstanceManager();
-    }
 
     public function testContainerDoesNotExist()
     {
@@ -52,9 +42,10 @@ class NavigationApiControllerTest extends AbstractHttpControllerTestCase
         $navigationService
             ->method('getNavigation')
             ->willThrowException(new ContainerNotFoundException());
-        $this->getApplication()
-            ->getServiceManager()
-            ->setService(NavigationService::class, $navigationService);
+        $this->getApplicationServiceLocator()->setService(
+            NavigationService::class,
+            $navigationService
+        );
 
         $this->dispatch('/api/navigation');
         $this->assertControllerName(NavigationApiController::class);
@@ -273,9 +264,10 @@ class NavigationApiControllerTest extends AbstractHttpControllerTestCase
         $navigationService
             ->method('getNavigation')
             ->will(new PHPUnit_Framework_MockObject_Stub_Return($data));
-        $this->getApplication()
-            ->getServiceManager()
-            ->setService(NavigationService::class, $navigationService);
+        $this->getApplicationServiceLocator()->setService(
+            NavigationService::class,
+            $navigationService
+        );
     }
 
     protected function assertJsonResponseWithInstance(

--- a/packages/public/server/src/module/User/src/Factory/UserManagerFactory.php
+++ b/packages/public/server/src/module/User/src/Factory/UserManagerFactory.php
@@ -58,7 +58,7 @@ class UserManagerFactory implements FactoryInterface
         $instance->setMysqlTimestampForActiveCommunity(
             $serviceLocator->get('config')[
                 'mysql_timestamp_for_active_community'
-            ] ?? 'CURDATE()'
+            ]
         );
 
         return $instance;

--- a/packages/public/server/src/module/User/src/Factory/UserManagerFactory.php
+++ b/packages/public/server/src/module/User/src/Factory/UserManagerFactory.php
@@ -55,6 +55,11 @@ class UserManagerFactory implements FactoryInterface
         $instance->setHydrator($hydrator);
         $instance->setAuthenticationService($authService);
         $instance->setAuthorizationService($authorizationService);
+        $instance->setMysqlTimestampForActiveCommunity(
+            $serviceLocator->get('config')[
+                'mysql_timestamp_for_active_community'
+            ] ?? 'CURDATE()'
+        );
 
         return $instance;
     }

--- a/packages/public/server/src/module/User/src/Manager/UserManager.php
+++ b/packages/public/server/src/module/User/src/Manager/UserManager.php
@@ -46,6 +46,16 @@ class UserManager implements UserManagerInterface
      */
     protected $hydrator;
 
+    /**
+     * @var string
+     */
+    protected $mysql_timestamp_for_active_community;
+
+    public function setMysqlTimestampForActiveCommunity(string $timestamp)
+    {
+        $this->mysql_timestamp_for_active_community = $timestamp;
+    }
+
     public function getUser($id)
     {
         $user = $this->getObjectManager()->find(
@@ -151,7 +161,9 @@ class UserManager implements UserManagerInterface
         return $this->getIds(
             'SELECT user.id as id, count(event_log.event_id) AS edit_counts ' .
                 'FROM user JOIN event_log on user.id = event_log.actor_id ' .
-                'WHERE event_log.event_id = 5 and event_log.date > DATE_SUB(CURDATE(), Interval 90 day) ' .
+                'WHERE event_log.event_id = 5 and event_log.date > DATE_SUB(' .
+                $this->mysql_timestamp_for_active_community .
+                ', Interval 90 day) ' .
                 'GROUP BY user.id ' .
                 'HAVING edit_counts > 10'
         );
@@ -165,7 +177,9 @@ class UserManager implements UserManagerInterface
                 'JOIN event_log AS e2 ON e1.uuid_id = e2.uuid_id AND (e1.event_id = 6 or e1.event_id = 11) ' .
                 'AND e2.event_id = 5 AND e1.date >= e2.date AND e1.actor_id != e2.actor_id ' .
                 'JOIN user ON user.id = e1.actor_id ' .
-                'WHERE e1.date > DATE_SUB(CURDATE(), Interval 90 day) ' .
+                'WHERE e1.date > DATE_SUB(' .
+                $this->mysql_timestamp_for_active_community .
+                ', Interval 90 day) ' .
                 'GROUP BY user.id ' .
                 'HAVING edit_counts > 10'
         );

--- a/packages/public/server/src/module/User/src/Manager/UserManager.php
+++ b/packages/public/server/src/module/User/src/Manager/UserManager.php
@@ -146,6 +146,26 @@ class UserManager implements UserManagerInterface
         return $user;
     }
 
+    public function getActiveAuthorIds()
+    {
+        $sql =
+            'SELECT user.id as id, count(event_log.event_id) AS edit_counts ' .
+            'FROM user JOIN event_log on user.id = event_log.actor_id ' .
+            "WHERE event_log.event_id = 5 and event_log.date > DATE_SUB(CURDATE(), Interval 90 day) " .
+            'GROUP BY user.id ' .
+            'HAVING edit_counts > 10';
+        $q = $this->objectManager->getConnection()->prepare($sql);
+        $q->execute();
+        $queryResultNested = $q->fetchAll();
+        $result = [];
+        foreach ($queryResultNested as $queryResult) {
+            $result[] = $queryResult['id'];
+        }
+        return array_map(function ($x) {
+            return (int) $x;
+        }, $result);
+    }
+
     public function findAllUsers($page = 0, $limit = 50)
     {
         $className = $this->getClassResolver()->resolveClassName(

--- a/packages/public/server/src/module/User/src/Manager/UserManager.php
+++ b/packages/public/server/src/module/User/src/Manager/UserManager.php
@@ -148,12 +148,31 @@ class UserManager implements UserManagerInterface
 
     public function getActiveAuthorIds()
     {
-        $sql =
+        return $this->getIds(
             'SELECT user.id as id, count(event_log.event_id) AS edit_counts ' .
-            'FROM user JOIN event_log on user.id = event_log.actor_id ' .
-            "WHERE event_log.event_id = 5 and event_log.date > DATE_SUB(CURDATE(), Interval 90 day) " .
-            'GROUP BY user.id ' .
-            'HAVING edit_counts > 10';
+                'FROM user JOIN event_log on user.id = event_log.actor_id ' .
+                'WHERE event_log.event_id = 5 and event_log.date > DATE_SUB(CURDATE(), Interval 90 day) ' .
+                'GROUP BY user.id ' .
+                'HAVING edit_counts > 10'
+        );
+    }
+
+    public function getActiveReviewerIds()
+    {
+        return $this->getIds(
+            'SELECT user.id AS id, user.username, count(e1.event_id) AS edit_counts ' .
+                'FROM event_log AS e1 ' .
+                'JOIN event_log AS e2 ON e1.uuid_id = e2.uuid_id AND (e1.event_id = 6 or e1.event_id = 11) ' .
+                'AND e2.event_id = 5 AND e1.date >= e2.date AND e1.actor_id != e2.actor_id ' .
+                'JOIN user ON user.id = e1.actor_id ' .
+                'WHERE e1.date > DATE_SUB(CURDATE(), Interval 90 day) ' .
+                'GROUP BY user.id ' .
+                'HAVING edit_counts > 10'
+        );
+    }
+
+    protected function getIds(string $sql): array
+    {
         $q = $this->objectManager->getConnection()->prepare($sql);
         $q->execute();
         $queryResultNested = $q->fetchAll();

--- a/packages/public/server/src/module/User/src/Manager/UserManagerInterface.php
+++ b/packages/public/server/src/module/User/src/Manager/UserManagerInterface.php
@@ -37,6 +37,11 @@ interface UserManagerInterface extends Flushable, Persistable
     public function createUser(array $data);
 
     /**
+     * @return array
+     */
+    public function getActiveAuthorIds();
+
+    /**
      * @param int $page
      * @param int $limit
      * @return Paginator|UserInterface[]

--- a/packages/public/server/src/module/User/src/Manager/UserManagerInterface.php
+++ b/packages/public/server/src/module/User/src/Manager/UserManagerInterface.php
@@ -42,6 +42,11 @@ interface UserManagerInterface extends Flushable, Persistable
     public function getActiveAuthorIds();
 
     /**
+     * @return array
+     */
+    public function getActiveReviewerIds();
+
+    /**
      * @param int $page
      * @param int $limit
      * @return Paginator|UserInterface[]

--- a/packages/public/server/src/module/User/test/Stub/Manager/UserManagerStub.php
+++ b/packages/public/server/src/module/User/test/Stub/Manager/UserManagerStub.php
@@ -74,6 +74,11 @@ class UserManagerStub implements UserManagerInterface
         return [];
     }
 
+    public function getActiveReviewerIds()
+    {
+        return [];
+    }
+
     public function generateUserToken($id)
     {
         // TODO: Implement generateUserToken() method.

--- a/packages/public/server/src/module/User/test/Stub/Manager/UserManagerStub.php
+++ b/packages/public/server/src/module/User/test/Stub/Manager/UserManagerStub.php
@@ -69,6 +69,11 @@ class UserManagerStub implements UserManagerInterface
         // TODO: Implement findUserByUsername() method.
     }
 
+    public function getActiveAuthorIds()
+    {
+        return [];
+    }
+
     public function generateUserToken($id)
     {
         // TODO: Implement generateUserToken() method.


### PR DESCRIPTION
Add the routes `/api/user/active-authors` and `/api/user/active-authors` for accessing the ids for active authors / reviewers.

### Testing
Links:

* http://en.serlo.localhost:4567/api/user/active-reviewers
* http://en.serlo.localhost:4567/api/user/active-authors

 You can change the config [`$mysql_timestamp_for_active_community`](https://github.com/serlo/serlo.org/blob/378f0711909505164a7982b4ab1a8d7fb99a02d4/packages/public/server/src/config/definitions.local.php#L63) for changing the end date of the 90 days period in which the edits / reviews are calculated. You can execute `yarn mysql:import-anonymous-data` and change this value to `CURDATE()` to test the behavior in production. The current values should be similar to

* https://github.com/serlo/serlo.org/blob/master/packages/public/client/src/feature-prototypes/donation-profiles/active-reviewers.ts
* https://github.com/serlo/serlo.org/blob/master/packages/public/client/src/feature-prototypes/donation-profiles/active-authors.ts