### PR TITLE
server.api: Ignore pages without uri or route

### DIFF
--- a/packages/public/server/src/module/Api/src/Controller/NavigationApiController.php
+++ b/packages/public/server/src/module/Api/src/Controller/NavigationApiController.php
@@ -94,6 +94,9 @@ class NavigationApiController extends AbstractApiController
         ) {
             return null;
         }
+        if (array_key_exists('label', $parameters) && count($parameters) == 1) {
+            return null;
+        }
 
         $result = [];
 

--- a/packages/public/server/src/module/Api/test/Controller/NavigationApiControllerTest.php
+++ b/packages/public/server/src/module/Api/test/Controller/NavigationApiControllerTest.php
@@ -256,6 +256,20 @@ class NavigationApiControllerTest extends AbstractHttpControllerTestCase
         $this->assertJsonResponseWithInstance([], $this->getResponse());
     }
 
+    public function testPageWithoutRouteOrUriAreIgnored()
+    {
+        $this->stubNavigationService([
+            [
+                'parameters' => [
+                    'label' => 'School',
+                ],
+                'children' => [],
+            ],
+        ]);
+        $this->dispatch('/api/navigation');
+        $this->assertJsonResponseWithInstance([], $this->getResponse());
+    }
+
     protected function stubNavigationService(array $data)
     {
         $navigationService = $this->getMockBuilder(NavigationService::class)


### PR DESCRIPTION
Fixes https://github.com/serlo/api.serlo.org/issues/76 by ignoring elements in the navigation without an `uri` or `route`.