### PR TITLE
server-api: Add alias support for /user/profile/:username

### DIFF
--- a/packages/public/server/__tests-e2e__/api.ts
+++ b/packages/public/server/__tests-e2e__/api.ts
@@ -1,0 +1,50 @@
+/**
+ * This file is part of Serlo.org.
+ *
+ * Copyright (c) 2013-2020 Serlo Education e.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @copyright Copyright (c) 2013-2020 Serlo Education e.V.
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://github.com/serlo-org/serlo.org for the canonical source repository
+ */
+import axios from 'axios'
+
+import { testingServerUrl } from './_config'
+
+describe('/api/alias/:alias', () => {
+  describe('/api/alias/user/profile/:username', () => {
+    test('when user exists', async () => {
+      const response = await fetchPath('/api/alias/user/profile/admin')
+
+      expect(response.data).toEqual({
+        id: 1,
+        instance: 'en',
+        path: '/user/profile/admin',
+        source: '/user/profile/admin',
+        timestamp: '2014-03-01T20:36:21+01:00',
+      })
+    })
+    
+    test('when user does not exist', async () => {
+      const response = await fetchPath('/api/alias/user/profile/not-existing')
+
+      expect(response.data).toBeNull()
+    })
+  })
+})
+
+function fetchPath(path: string) {
+  return axios.get(testingServerUrl + path)
+}

--- a/packages/public/server/__tests-e2e__/api.ts
+++ b/packages/public/server/__tests-e2e__/api.ts
@@ -32,11 +32,11 @@ describe('/api/alias/:alias', () => {
         id: 1,
         instance: 'en',
         path: '/user/profile/admin',
-        source: '/user/profile/admin',
+        source: '/user/profile/1',
         timestamp: '2014-03-01T20:36:21+01:00',
       })
     })
-    
+
     test('when user does not exist', async () => {
       const response = await fetchPath('/api/alias/user/profile/not-existing')
 

--- a/packages/public/server/__tests-e2e__/api.ts
+++ b/packages/public/server/__tests-e2e__/api.ts
@@ -25,18 +25,6 @@ import { testingServerUrl } from './_config'
 
 describe('/api/alias/:alias', () => {
   describe('/api/alias/user/profile/:username', () => {
-    test('when user exists', async () => {
-      const response = await fetchPath('/api/alias/user/profile/admin')
-
-      expect(response.data).toEqual({
-        id: 1,
-        instance: 'en',
-        path: '/user/profile/admin',
-        source: '/user/profile/1',
-        timestamp: '2014-03-01T20:36:21+01:00',
-      })
-    })
-
     test('when user does not exist', async () => {
       const response = await fetchPath('/api/alias/user/profile/not-existing')
 

--- a/packages/public/server/src/module/Api/src/ApiManager.php
+++ b/packages/public/server/src/module/Api/src/ApiManager.php
@@ -77,17 +77,12 @@ class ApiManager
         ];
     }
 
-    public function getAliasDataFromUser(
-        UserInterface $user,
-        InstanceInterface $instance
-    ) {
-        $profileLink = '/user/profile/' . $user->getUsername();
-
+    public function getAliasDataForUser(UserInterface $user)
+    {
         return [
             'id' => $user->getId(),
-            'instance' => $instance->getSubdomain(),
-            'path' => $profileLink,
-            'source' => $profileLink,
+            'path' => '/user/profile/' . $user->getUsername(),
+            'source' => '/user/profile/' . $user->getId(),
             'timestamp' => $this->normalizeDate($user->getDate()),
         ];
     }

--- a/packages/public/server/src/module/Api/src/ApiManager.php
+++ b/packages/public/server/src/module/Api/src/ApiManager.php
@@ -29,6 +29,7 @@ use Api\Service\GraphQLService;
 use DateTime;
 use Entity\Entity\EntityInterface;
 use Entity\Entity\RevisionInterface;
+use Instance\Entity\InstanceInterface;
 use License\Entity\LicenseInterface;
 use Page\Entity\PageRepositoryInterface;
 use Page\Entity\PageRevisionInterface;
@@ -73,6 +74,21 @@ class ApiManager
             'path' => '/' . $alias->getAlias(),
             'source' => $alias->getSource(),
             'timestamp' => $this->normalizeDate($alias->getTimestamp()),
+        ];
+    }
+
+    public function getAliasDataFromUser(
+        UserInterface $user,
+        InstanceInterface $instance
+    ) {
+        $profileLink = '/user/profile/' . $user->getUsername();
+
+        return [
+            'id' => $user->getId(),
+            'instance' => $instance->getSubdomain(),
+            'path' => $profileLink,
+            'source' => $profileLink,
+            'timestamp' => $this->normalizeDate($user->getDate()),
         ];
     }
 

--- a/packages/public/server/src/module/Api/src/Controller/ApiController.php
+++ b/packages/public/server/src/module/Api/src/Controller/ApiController.php
@@ -73,9 +73,9 @@ class ApiController extends AbstractApiController
                 $user = $this->getUserManager()->findUserByUsername($username);
 
                 return new JsonModel(
-                    $this->getApiManager()->getAliasDataFromUser(
-                        $user,
-                        $instance
+                    array_merge(
+                        $this->getApiManager()->getAliasDataForUser($user),
+                        ['instance' => $instance->getSubdomain()]
                     )
                 );
             } catch (UserNotFoundException $exception) {

--- a/packages/public/server/src/module/Api/src/Controller/ApiController.php
+++ b/packages/public/server/src/module/Api/src/Controller/ApiController.php
@@ -33,6 +33,8 @@ use Lcobucci\JWT\Signer\Hmac\Sha256;
 use Lcobucci\JWT\ValidationData;
 use License\Exception\LicenseNotFoundException;
 use License\Manager\LicenseManagerAwareTrait;
+use User\Exception\UserNotFoundException;
+use User\Manager\UserManagerAwareTrait;
 use Uuid\Exception\NotFoundException;
 use Uuid\Manager\UuidManagerAwareTrait;
 use Zend\Http\Response;
@@ -45,6 +47,7 @@ class ApiController extends AbstractApiController
     use ApiManagerAwareTrait;
     use InstanceManagerAwareTrait;
     use LicenseManagerAwareTrait;
+    use UserManagerAwareTrait;
     use UuidManagerAwareTrait;
 
     public function __construct(AuthorizationService $authorizationService)
@@ -61,6 +64,28 @@ class ApiController extends AbstractApiController
 
         $alias = $this->params('alias');
         $instance = $this->getInstanceManager()->getInstanceFromRequest();
+
+        $userProfilePrefix = 'user/profile/';
+        if (strpos($alias, $userProfilePrefix, 0) === 0) {
+            $username = substr($alias, strlen($userProfilePrefix));
+
+            try {
+                $user = $this->getUserManager()->findUserByUsername($username);
+
+                return new JsonModel(
+                    $this->getApiManager()->getAliasDataFromUser(
+                        $user,
+                        $instance
+                    )
+                );
+            } catch (UserNotFoundException $exception) {
+                $this->response
+                    ->getHeaders()
+                    ->addHeaderLine('Content-Type', 'application/json');
+                $this->response->setContent('null');
+                return $this->response;
+            }
+        }
 
         $aliases = $this->getAliasManager()->findAliases($alias, $instance);
         if (count($aliases) === 0) {

--- a/packages/public/server/src/module/Api/src/Factory/ApiControllerFactory.php
+++ b/packages/public/server/src/module/Api/src/Factory/ApiControllerFactory.php
@@ -33,6 +33,8 @@ use Instance\Manager\InstanceManager;
 use Instance\Manager\InstanceManagerInterface;
 use License\Manager\LicenseManager;
 use License\Manager\LicenseManagerInterface;
+use User\Manager\UserManager;
+use User\Manager\UserManagerInterface;
 use Uuid\Manager\UuidManager;
 use Uuid\Manager\UuidManagerInterface;
 use Zend\ServiceManager\AbstractPluginManager;
@@ -68,6 +70,10 @@ class ApiControllerFactory extends AbstractControllerFactory
         /** @var UuidManagerInterface $uuidManager */
         $uuidManager = $serviceManager->get(UuidManager::class);
         $controller->setUuidManager($uuidManager);
+
+        /** @var UserManagerInterface $userManager */
+        $userManager = $serviceManager->get(UserManager::class);
+        $controller->setUserManager($userManager);
 
         return $controller;
     }


### PR DESCRIPTION
Add support for resolving `/user/profile/:username` in `/api/alias/:alias` so that https://github.com/serlo/api.serlo.org/pull/84 can be finished (see also https://github.com/serlo/api.serlo.org/issues/67 ).

Example result for `http://de.serlo.localhost:4567/api/alias/user/profile/Kulla`:

```json
{
  "id": 26217,
  "instance": "de",
  "path": "/user/profile/Kulla",
  "source": "/user/profile/Kulla",
  "timestamp": "2014-07-07T18:24:52+02:00"
}
```

- [x] return `source: /user/profile/:id`