### PR TITLE
server: Fix bug in /api/event/:id

### DIFF
--- a/packages/public/server/src/module/Api/src/Manager/NotificationApiManager.php
+++ b/packages/public/server/src/module/Api/src/Manager/NotificationApiManager.php
@@ -229,18 +229,20 @@ class NotificationApiManager
                     'reason' => $event->getParameter('reason') ?? '',
                 ];
             case 'taxonomy/term/associate':
+                $object = $event->getParameter('object');
                 return [
                     '__typename' => 'CreateTaxonomyLinkNotificationEvent',
                     'actorId' => $event->getActor()->getId(),
                     'parentId' => $event->getObject()->getId(),
-                    'childId' => $event->getParameter('object')->getId(),
+                    'childId' => $object ? $object->getId() : null,
                 ];
             case 'taxonomy/term/dissociate':
+                $object = $event->getParameter('object');
                 return [
                     '__typename' => 'RemoveTaxonomyLinkNotificationEvent',
                     'actorId' => $event->getActor()->getId(),
                     'parentId' => $event->getObject()->getId(),
-                    'childId' => $event->getParameter('object')->getId(),
+                    'childId' => $object ? $object->getId() : null,
                 ];
             case 'taxonomy/term/create':
                 return [
@@ -261,8 +263,10 @@ class NotificationApiManager
                     '__typename' => 'SetTaxonomyParentNotificationEvent',
                     'actorId' => $event->getActor()->getId(),
                     'childId' => $event->getObject()->getId(),
-                    'previousParentId' => $from ? $from->getId() : null,
-                    'parentId' => $to ? $to->getId() : null,
+                    'previousParentId' =>
+                        $from && $from != 'no parent' ? $from->getId() : null,
+                    'parentId' =>
+                        $to && $to != 'no parent' ? $to->getId() : null,
                 ];
             case 'uuid/restore':
                 return [


### PR DESCRIPTION
Fixes #519 There are events of the kind `taxonomy/term/associate` and
`taxonomy/term/dissociate` where the child uuid might be null (This might
be due to deleted uuids from the database). Also for some events of the
kind `taxonomy/term/parent/change` the previous or the new parent is set
to `"no parent"` in the database. This might be du to a bug or an old
behavior of the Serlo software.