### PR TITLE
server: Replace "unfetch" with "node-fetch"

### DIFF
--- a/packages/public/server/__tests-e2e__/api.ts
+++ b/packages/public/server/__tests-e2e__/api.ts
@@ -19,7 +19,7 @@
  * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
  * @link      https://github.com/serlo-org/serlo.org for the canonical source repository
  */
-import fetch from 'unfetch'
+import fetch from 'node-fetch'
 
 import { testingServerUrl } from './_config'
 
@@ -39,6 +39,8 @@ describe('/api/subscriptions/:userId', () => {
   })
 })
 
-function fetchPath(path: string) {
-  return fetch(testingServerUrl + path).then((response) => response.json())
+async function fetchPath(path: string) {
+  const response = await fetch(testingServerUrl + path)
+
+  return await response.json()
 }

--- a/packages/public/server/__tests-e2e__/mails.ts
+++ b/packages/public/server/__tests-e2e__/mails.ts
@@ -20,7 +20,7 @@
  * @link      https://github.com/serlo-org/serlo.org for the canonical source repository
  */
 import { getDocument, queries } from 'pptr-testing-library'
-import fetch from 'unfetch'
+import fetch from 'node-fetch'
 
 test('Reset password mail renders correctly', async () => {
   const username = 'admin'

--- a/packages/public/server/package.json
+++ b/packages/public/server/package.json
@@ -16,10 +16,10 @@
     "@types/puppeteer": "^5.0.0",
     "@types/ramda": "^0.27.0",
     "jest-matcher-utils": "^26.0.0",
+    "node-fetch": "^2.0.0",
     "npm-run-all": "^4.0.0",
     "pptr-testing-library": "^0.6.0",
     "puppeteer": "^5.0.0",
-    "ramda": "^0.27.0",
-    "unfetch": "^4.0.0"
+    "ramda": "^0.27.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14318,7 +14318,7 @@ node-fetch-npm@^2.0.2:
     json-parse-better-errors "^1.0.0"
     safe-buffer "^5.1.1"
 
-node-fetch@^2.5.0, node-fetch@^2.6.0, node-fetch@^2.6.1:
+node-fetch@^2.0.0, node-fetch@^2.5.0, node-fetch@^2.6.0, node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==


### PR DESCRIPTION
Fixes our e2e tests. unfetch only works in the browser. Thus we need node-fetch
in our e2e tests since they run in Node.js.