### PR TITLE
server: Add "objectId" to /api/event/:id

### DIFF
--- a/packages/public/server/src/module/Api/src/Manager/NotificationApiManager.php
+++ b/packages/public/server/src/module/Api/src/Manager/NotificationApiManager.php
@@ -103,6 +103,7 @@ class NotificationApiManager
                 'id' => $event->getId(),
                 'instance' => $event->getInstance()->getSubdomain(),
                 'date' => $this->normalizeDate($event->getTimestamp()),
+                'objectId' => $event->getObject()->getId(),
             ],
             $normalized
         );
@@ -269,14 +270,12 @@ class NotificationApiManager
                 return [
                     '__typename' => 'SetUuidStateNotificationEvent',
                     'actorId' => $event->getActor()->getId(),
-                    'objectId' => $event->getObject()->getId(),
                     'trashed' => false,
                 ];
             case 'uuid/trash':
                 return [
                     '__typename' => 'SetUuidStateNotificationEvent',
                     'actorId' => $event->getActor()->getId(),
-                    'objectId' => $event->getObject()->getId(),
                     'trashed' => true,
                 ];
             default:


### PR DESCRIPTION
Needed for https://github.com/serlo/api.serlo.org/issues/92

Here is the only exception, where `objectId` is defined differently:

```php
            case 'discussion/create':
                return [
                    '__typename' => 'CreateThreadNotificationEvent',
                    'actorId' => $event->getActor()->getId(),
                    'threadId' => $event->getObject()->getId(),
                    'objectId' => $event->getParameter('on')->getId(),
                ];
```