### PR TITLE
Add hash to redirects when storing a revision

### DIFF
--- a/packages/public/server/src/module/Entity/src/Controller/EntityController.php
+++ b/packages/public/server/src/module/Entity/src/Controller/EntityController.php
@@ -70,6 +70,17 @@ class EntityController extends AbstractController
         return true;
     }
 
+    public function unrevisedAction()
+    {
+        $view = new ViewModel([
+            'revisionsBySubject' => $this->getUnrevisedRevisionsBySubject(),
+            'helpLinks' => $this->getReviewHelpLinks(),
+        ]);
+        $view->setTemplate('entity/unrevised');
+
+        return $view;
+    }
+
     protected function getUnrevisedRevisionsBySubject()
     {
         $revisions = $this->getEntityManager()
@@ -147,16 +158,5 @@ class EntityController extends AbstractController
         ];
 
         return $helpLinks;
-    }
-
-    public function unrevisedAction()
-    {
-        $view = new ViewModel([
-            'revisionsBySubject' => $this->getUnrevisedRevisionsBySubject(),
-            'helpLinks' => $this->getReviewHelpLinks(),
-        ]);
-        $view->setTemplate('entity/unrevised');
-
-        return $view;
     }
 }

--- a/packages/public/server/src/module/Entity/src/Controller/RepositoryController.php
+++ b/packages/public/server/src/module/Entity/src/Controller/RepositoryController.php
@@ -449,8 +449,9 @@ class RepositoryController extends AbstractController
         $this->getEntityManager()->flush();
         $this->flashMessenger()->addSuccessMessage($successMessage);
 
-        $entityId = ['entity' => $entity->getId()];
-        return $this->plugin('url')->fromRoute($route, $entityId) . $hash;
+        return $this->plugin('url')->fromRoute($route, [
+            'entity' => $entity->getId(),
+        ]) . $hash;
     }
 
     public function checkoutAction()
@@ -473,8 +474,9 @@ class RepositoryController extends AbstractController
         );
         $this->getRepositoryManager()->flush();
 
-        $entityId = ['entity' => $entity->getId()];
-        $url = $this->plugin('url')->fromRoute('entity/page', $entityId);
+        $url = $this->plugin('url')->fromRoute('entity/page', [
+            'entity' => $entity->getId(),
+        ]);
         return $this->redirect()->toUrl($url . '#revision-accepted');
     }
 


### PR DESCRIPTION
Closes #553 

This PR implements (ping @elbotho ):

* Adds `#revision-saved` when a revision is saved but needs to be reviewed
* Adds `#revision-accepted` when a revision was successfully checkout out / accepted
* Adds `#revision-rejected` when a revision was successfully rejected
* Adds `#revision-saved-accepted` when a revision was successfully saved and accepted