### PR TITLE
/api/subscriptions: Return null when user does not exist

### DIFF
--- a/packages/public/server/src/module/Api/src/Controller/ApiController.php
+++ b/packages/public/server/src/module/Api/src/Controller/ApiController.php
@@ -113,7 +113,7 @@ class ApiController extends AbstractApiController
                 $this->getApiManager()->getSubscriptionsData($user)
             );
         } catch (UserNotFoundException $exception) {
-            $this->createJsonResponse('null');
+            return $this->createJsonResponse('null');
         }
     }
 


### PR DESCRIPTION
Fixes current e2e tests