### PR TITLE
Renamed topic "boite a methodes" to "conseils pour apprendre" 

### DIFF
--- a/packages/public/server/src/module/Subject/config/instances.config.php
+++ b/packages/public/server/src/module/Subject/config/instances.config.php
@@ -170,7 +170,7 @@ return [
                         'applet',
                     ],
                 ],
-                'boîte à méthodes' => [
+                'conseils pour apprendre' => [
                     'allowed_taxonomies' => ['topic', 'locale'],
                     'allowed_entities' => [
                         'article',


### PR DESCRIPTION
Similarly to the German version where the topic "Methodenkiste" got renamed to "Lerntipps", we decided to rename "Boite a methodes" to "conseils pour apprendre".  