### PR TITLE
listener: Update parent for newly created uuid

### DIFF
--- a/packages/public/server/src/module/Api/src/Listener/LinkServiceListener.php
+++ b/packages/public/server/src/module/Api/src/Listener/LinkServiceListener.php
@@ -35,13 +35,10 @@ class LinkServiceListener extends AbstractListener
     {
         /** @var UuidInterface $uuid */
         $child = $e->getParam('entity');
-
-        $newlyCreated = !$child->getId();
-        if ($newlyCreated) {
-            return;
+        // Only update child when it is not newly created
+        if ($child->getId()) {
+            $this->getApiManager()->setUuid($child);
         }
-
-        $this->getApiManager()->setUuid($child);
 
         /** @var UuidInterface $uuid */
         $parent = $e->getParam('parent');


### PR DESCRIPTION
The parent on a link change needs to be updated when the uuid is newly
created. Otherwise for example the course is not updated when a new
course page is created or an exercise is not updated when a solution is
added.