### PR TITLE
Fix error when entity children are ordered

### DIFF
--- a/packages/public/server/src/module/Api/src/ApiManager.php
+++ b/packages/public/server/src/module/Api/src/ApiManager.php
@@ -103,9 +103,8 @@ class ApiManager
 
     public function removeUuid($id)
     {
-        $this->graphql->setCache(
-            $this->graphql->getCacheKey('/api/uuid/' . $id),
-            null
+        $this->graphql->removeCache(
+            $this->graphql->getCacheKey('/api/uuid/' . $id)
         );
     }
 

--- a/packages/public/server/src/module/Api/src/Listener/LinkServiceListener.php
+++ b/packages/public/server/src/module/Api/src/Listener/LinkServiceListener.php
@@ -52,6 +52,13 @@ class LinkServiceListener extends AbstractListener
         $this->getApiManager()->setUuid($term);
     }
 
+    public function onSortChildren(Event $e)
+    {
+        /** @var UuidInterface $parent */
+        $parent = $e->getParam('parent');
+        $this->getApiManager()->removeUuid($parent->getId());
+    }
+
     public function attachShared(SharedEventManagerInterface $events)
     {
         $events->attach(
@@ -64,6 +71,12 @@ class LinkServiceListener extends AbstractListener
             $this->getMonitoredClass(),
             'link',
             [$this, 'onLinkChange'],
+            2
+        );
+        $events->attach(
+            $this->getMonitoredClass(),
+            'sortChildren',
+            [$this, 'onSortChildren'],
             2
         );
     }

--- a/packages/public/server/src/module/Api/src/Service/AbstractGraphQLService.php
+++ b/packages/public/server/src/module/Api/src/Service/AbstractGraphQLService.php
@@ -44,4 +44,14 @@ MUTATION;
             'value' => $value,
         ]);
     }
+
+    public function removeCache($key)
+    {
+        $query = <<<MUTATION
+            mutation _removeCache(\$key: String!) {
+                _removeCache(key: \$key)
+            }
+MUTATION;
+        $this->exec($query, ['key' => $key]);
+    }
 }

--- a/packages/public/server/src/module/Entity/src/Controller/LinkController.php
+++ b/packages/public/server/src/module/Entity/src/Controller/LinkController.php
@@ -25,6 +25,7 @@ namespace Entity\Controller;
 use Entity\Form\MoveForm;
 use Entity\Options\ModuleOptionsAwareTrait;
 use Link\Service\LinkServiceAwareTrait;
+use Zend\View\Model\JsonModel;
 use Zend\View\Model\ViewModel;
 
 class LinkController extends AbstractController
@@ -102,10 +103,11 @@ class LinkController extends AbstractController
 
             $this->getLinkService()->sortChildren($entity, $scope, $data);
             $this->getEntityManager()->flush();
-            $this->flashMessenger()->addSuccessMessage(
-                'Your changes have been saved.'
-            );
-            return $this->redirect()->toUrl($this->referer()->fromStorage());
+
+            return new JsonModel([
+                'success' => true,
+                'redirect' => $this->referer()->fromStorage(),
+            ]);
         } else {
             $this->referer()->store();
         }

--- a/packages/public/server/src/module/Link/src/Service/LinkService.php
+++ b/packages/public/server/src/module/Link/src/Service/LinkService.php
@@ -117,6 +117,10 @@ class LinkService implements LinkServiceInterface
             $i++;
         }
 
+        $this->getEventManager()->trigger('sortChildren', $this, [
+            'parent' => $parent,
+        ]);
+
         return $this;
     }
 


### PR DESCRIPTION
This fixes an error when the children of an entity are ordered in the local environment since the new site cannot be rendered.

### Description of current error

When the order of course pages are changed by the following tool

![2021-04-27-161503_939x429_scrot](https://user-images.githubusercontent.com/1327215/116261585-12e76200-a778-11eb-8fea-e08866f298e8.png)

there is an error displayed clicking the "save" button:

![2021-04-27-164514_1246x463_scrot](https://user-images.githubusercontent.com/1327215/116261660-272b5f00-a778-11eb-99a5-4311ead05c28.png)

### The reason of the error

Currently after changing the order with the POST request there is a redirect to the new course page https://github.com/serlo/serlo.org/blob/7e75da6d79ba04f1d592dec6e73ae3d4c1d52d82/packages/public/server/src/module/Entity/src/Controller/LinkController.php#L50-L83 However the new course page cannot be displayed since the following error occurs 
![2021-04-27-165152_947x500_scrot](https://user-images.githubusercontent.com/1327215/116262544-ed0e8d00-a778-11eb-8dbe-952ea935c444.png)

The fix is to not redirect to the new course but to return a success immediately.


