### PR TITLE
Fix: revisions are not shown at /entity/unrevised

### DIFF
--- a/packages/public/server/src/module/Entity/src/Controller/EntityController.php
+++ b/packages/public/server/src/module/Entity/src/Controller/EntityController.php
@@ -84,7 +84,9 @@ class EntityController extends AbstractController
     protected function getUnrevisedRevisionsBySubject()
     {
         $revisions = $this->getEntityManager()
-            ->findAllUnrevisedRevisions()
+            ->findAllUnrevisedRevisions(
+                $this->getInstanceManager()->getInstanceFromRequest()
+            )
             ->getIterator();
 
         $revisions->uasort(function ($revisionA, $revisionB) {

--- a/packages/public/server/src/module/Entity/src/Manager/EntityManager.php
+++ b/packages/public/server/src/module/Entity/src/Manager/EntityManager.php
@@ -116,7 +116,7 @@ class EntityManager implements EntityManagerInterface
         return $entity;
     }
 
-    public function findAllUnrevisedRevisions($limit = 100)
+    public function findAllUnrevisedRevisions($limit = 200)
     {
         $entityClassName = $this->getClassResolver()->resolveClassName(
             'Entity\Entity\RevisionInterface'
@@ -129,7 +129,7 @@ class EntityManager implements EntityManagerInterface
             'INNER JOIN entity e ON e.id = r.repository_id ' .
             'INNER JOIN `uuid` u_e ON e.id = u_e.id ' .
             'WHERE ( e.current_revision_id IS NULL OR r.id > e.current_revision_id ) ' .
-            'AND u_r.trashed = 0 AND u_e.trashed = 0 LIMIT ' .
+            'AND u_r.trashed = 0 AND u_e.trashed = 0 order by r.id LIMIT ' .
             $limit;
         $q = $this->objectManager->getConnection()->prepare($sql);
         $q->execute();

--- a/packages/public/server/src/module/Entity/src/Manager/EntityManagerInterface.php
+++ b/packages/public/server/src/module/Entity/src/Manager/EntityManagerInterface.php
@@ -63,7 +63,10 @@ interface EntityManagerInterface extends Flushable
      *
      *  @return RevisionInterface[]|Collection
      */
-    public function findAllUnrevisedRevisions($limit);
+    public function findAllUnrevisedRevisions(
+        InstanceInterface $instance,
+        $limit
+    );
 
     /**
      * @param int $id


### PR DESCRIPTION
Fixes the current bug that there revisions missing in `/entity/unrevised`

Also closes https://github.com/serlo/serlo.org/issues/626