### PR TITLE
Increase max_input_vars

### DIFF
--- a/packages/public/server/docker/php/php.ini-custom
+++ b/packages/public/server/docker/php/php.ini-custom
@@ -3,6 +3,7 @@ extension=apc.so
 apc.enabled=On
 apc.enable_cli=On
 short_open_tag=Off
+max_input_vars=5000
 memory_limit=1024M
 realpath_cache_ttl=1200
 opcache.enable=1


### PR DESCRIPTION
Closes https://github.com/serlo/serlo.org/issues/649

Since PHP 5.39 there is the configutation max_input_vars (
https://www.php.net/manual/en/info.configuration.php#ini.max-input-vars
) which limits the amount of input variables. Since the page
`/entity/taxonomy/update/:id` sends a variable per term this number was
exceeded and the sended variables after 1000 were cut off. Thus after
the 1000th term no new assignments could be saved.