### PR TITLE
Fix bug in chrome with equations plugin

### DIFF
--- a/packages/private/edtr-io/src/plugins/equations/editor.tsx
+++ b/packages/private/edtr-io/src/plugins/equations/editor.tsx
@@ -101,6 +101,7 @@ export function EquationsEditor(props: EquationsProps) {
   React.useEffect(() => {
     if (nestedFocus) {
       gridFocus.setFocus({ row: 0, column: 0 })
+      store.dispatch(focus(props.id))
     }
   }, [nestedFocus])
 

--- a/packages/private/edtr-io/src/plugins/equations/editor.tsx
+++ b/packages/private/edtr-io/src/plugins/equations/editor.tsx
@@ -124,7 +124,12 @@ export function EquationsEditor(props: EquationsProps) {
                 column: StepSegment.Transform,
               })
             ) {
-              insertNewEquationAt(state.steps.length)
+              const index = state.steps.length
+              insertNewEquationAt(index)
+              gridFocus.setFocus({
+                row: index - 1,
+                column: StepSegment.Explanation,
+              })
             } else {
               gridFocus.moveRight()
             }
@@ -243,14 +248,19 @@ export function EquationsEditor(props: EquationsProps) {
       transform: '',
       explanation: { plugin: 'text' },
     })
-    gridFocus.setFocus({ row: index - 1, column: StepSegment.Explanation })
   }
 
   function renderAddButton() {
     if (!nestedFocus) return
 
     return (
-      <AddButton onClick={() => insertNewEquationAt(state.steps.length)}>
+      <AddButton
+        onClick={() => {
+          const index = state.steps.length
+          insertNewEquationAt(index)
+          gridFocus.setFocus({ row: index, column: StepSegment.Left })
+        }}
+      >
         {i18n.t('equations::add new equation')}
       </AddButton>
     )

--- a/packages/private/edtr-io/src/plugins/equations/editor.tsx
+++ b/packages/private/edtr-io/src/plugins/equations/editor.tsx
@@ -141,7 +141,7 @@ export function EquationsEditor(props: EquationsProps) {
         INSERT: (e) => {
           handleKeyDown(e, () => {
             if (!gridFocus.focus) return
-            insertNewEquationAt(gridFocus.focus.row + 1)
+            insertNewEquationWithFocus(gridFocus.focus.row + 1)
           })
         },
       }}
@@ -250,17 +250,16 @@ export function EquationsEditor(props: EquationsProps) {
     })
   }
 
+  function insertNewEquationWithFocus(index: number) {
+    insertNewEquationAt(index)
+    gridFocus.setFocus({ row: index, column: StepSegment.Left })
+  }
+
   function renderAddButton() {
     if (!nestedFocus) return
 
     return (
-      <AddButton
-        onClick={() => {
-          const index = state.steps.length
-          insertNewEquationAt(index)
-          gridFocus.setFocus({ row: index, column: StepSegment.Left })
-        }}
-      >
+      <AddButton onClick={() => insertNewEquationWithFocus(state.steps.length)}>
         {i18n.t('equations::add new equation')}
       </AddButton>
     )

--- a/packages/private/edtr-io/src/plugins/equations/editor.tsx
+++ b/packages/private/edtr-io/src/plugins/equations/editor.tsx
@@ -243,7 +243,7 @@ export function EquationsEditor(props: EquationsProps) {
       transform: '',
       explanation: { plugin: 'text' },
     })
-    gridFocus.setFocus({ row: index, column: StepSegment.Left })
+    gridFocus.setFocus({ row: index - 1, column: StepSegment.Explanation })
   }
 
   function renderAddButton() {

--- a/packages/public/client/package.json
+++ b/packages/public/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serlo/client",
-  "version": "22.1.2",
+  "version": "22.1.3",
   "private": true,
   "scripts": {
     "prebuild": "rimraf dist",


### PR DESCRIPTION
This PR includes two things:

* When a new line is added with the `tab` shortcut the previous explanation instead of the left statement gets focus
* Fixes a bug in chrome that for a new equation element both the left statement and the explanation have focus. Entering a character in this state would move the cursor from the left field to the explanation

Due to the severity of the bug I would like to include this before the other improvements.