### PR TITLE
edtr-io: remove react-virtual

### DIFF
--- a/packages/private/edtr-io/package.json
+++ b/packages/private/edtr-io/package.json
@@ -53,7 +53,6 @@
     "react-hotkeys": "^2.0.0",
     "react-is": "^17.0.0",
     "react-modal": "^3.0.0",
-    "react-virtual": "^2.0.0",
     "redux": "^4.0.0",
     "slate": "^0.47.0",
     "slate-plain-serializer": "^0.7.0",

--- a/packages/private/edtr-io/src/plugins/types/text-exercise-group.tsx
+++ b/packages/private/edtr-io/src/plugins/types/text-exercise-group.tsx
@@ -36,7 +36,6 @@ import { RevisionHistory } from './helpers/settings'
 import { SemanticSection } from '../helpers/semantic-section'
 import { useVirtual } from 'react-virtual'
 
-
 // https://github.com/tannerlinsley/react-virtual/issues/167
 function useVirtualResizeObserver<T>(options: {
   size: number

--- a/packages/private/edtr-io/src/plugins/types/text-exercise-group.tsx
+++ b/packages/private/edtr-io/src/plugins/types/text-exercise-group.tsx
@@ -36,6 +36,71 @@ import { RevisionHistory } from './helpers/settings'
 import { SemanticSection } from '../helpers/semantic-section'
 import { useVirtual } from 'react-virtual'
 
+
+// https://github.com/tannerlinsley/react-virtual/issues/167
+function useVirtualResizeObserver<T>(options: {
+  size: number
+  parentRef: React.RefObject<T>
+  estimateSize: () => number
+}) {
+  const measureRefCacheRef = React.useRef<
+    Record<string, (el: HTMLElement | null) => void>
+  >({})
+  const elCacheRef = React.useRef<Record<number, HTMLElement | null>>({})
+
+  const resizeObserverRef = React.useRef(
+    new ResizeObserver((entries) => {
+      entries.forEach((entry) => {
+        const el = entry.target as HTMLElement
+        const index = el.getAttribute('data-index')
+        if (index !== null) measureRefCacheRef.current[index](el)
+      })
+    })
+  )
+
+  React.useEffect(() => {
+    const resizeObserver = resizeObserverRef.current
+    return () => {
+      resizeObserver.disconnect()
+    }
+  }, [])
+
+  const rowVirtualizer = useVirtual<T>(options)
+
+  const refs = React.useMemo(() => {
+    const obj: Record<number, (el: HTMLElement | null) => void> = {}
+    for (let i = 0; i < options.size; i++) {
+      obj[i] = (el: HTMLElement | null) => {
+        const currentElCache = elCacheRef.current[i]
+        if (currentElCache) {
+          resizeObserverRef.current.unobserve(currentElCache)
+        }
+
+        if (el) {
+          // sync
+          measureRefCacheRef.current[i](el)
+
+          el.setAttribute('data-index', i.toString())
+          resizeObserverRef.current.observe(el)
+        }
+
+        elCacheRef.current[i] = el
+      }
+    }
+    return obj
+  }, [options.size])
+
+  for (let i = 0; i < rowVirtualizer.virtualItems.length; i++) {
+    const item = rowVirtualizer.virtualItems[i]
+    if (item.measureRef !== refs[item.index]) {
+      measureRefCacheRef.current[item.index] = item.measureRef
+    }
+    item.measureRef = refs[item.index]
+  }
+
+  return rowVirtualizer
+}
+
 export const textExerciseGroupTypeState = entityType(
   {
     ...entity,
@@ -64,7 +129,7 @@ function TextExerciseGroupTypeEditor(
 
   const virtualParent = React.useRef(null)
 
-  const virtualizer = useVirtual({
+  const virtualizer = useVirtualResizeObserver({
     size: children.length,
     parentRef: virtualParent,
     estimateSize: React.useCallback(() => 35, []),

--- a/packages/private/edtr-io/src/plugins/types/text-exercise-group.tsx
+++ b/packages/private/edtr-io/src/plugins/types/text-exercise-group.tsx
@@ -34,71 +34,6 @@ import {
 } from './common'
 import { RevisionHistory } from './helpers/settings'
 import { SemanticSection } from '../helpers/semantic-section'
-import { useVirtual } from 'react-virtual'
-
-// https://github.com/tannerlinsley/react-virtual/issues/167
-function useVirtualResizeObserver<T>(options: {
-  size: number
-  parentRef: React.RefObject<T>
-  estimateSize: () => number
-}) {
-  const measureRefCacheRef = React.useRef<
-    Record<string, (el: HTMLElement | null) => void>
-  >({})
-  const elCacheRef = React.useRef<Record<number, HTMLElement | null>>({})
-
-  const resizeObserverRef = React.useRef(
-    new ResizeObserver((entries) => {
-      entries.forEach((entry) => {
-        const el = entry.target as HTMLElement
-        const index = el.getAttribute('data-index')
-        if (index !== null) measureRefCacheRef.current[index](el)
-      })
-    })
-  )
-
-  React.useEffect(() => {
-    const resizeObserver = resizeObserverRef.current
-    return () => {
-      resizeObserver.disconnect()
-    }
-  }, [])
-
-  const rowVirtualizer = useVirtual<T>(options)
-
-  const refs = React.useMemo(() => {
-    const obj: Record<number, (el: HTMLElement | null) => void> = {}
-    for (let i = 0; i < options.size; i++) {
-      obj[i] = (el: HTMLElement | null) => {
-        const currentElCache = elCacheRef.current[i]
-        if (currentElCache) {
-          resizeObserverRef.current.unobserve(currentElCache)
-        }
-
-        if (el) {
-          // sync
-          measureRefCacheRef.current[i](el)
-
-          el.setAttribute('data-index', i.toString())
-          resizeObserverRef.current.observe(el)
-        }
-
-        elCacheRef.current[i] = el
-      }
-    }
-    return obj
-  }, [options.size])
-
-  for (let i = 0; i < rowVirtualizer.virtualItems.length; i++) {
-    const item = rowVirtualizer.virtualItems[i]
-    if (item.measureRef !== refs[item.index]) {
-      measureRefCacheRef.current[item.index] = item.measureRef
-    }
-    item.measureRef = refs[item.index]
-  }
-
-  return rowVirtualizer
-}
 
 export const textExerciseGroupTypeState = entityType(
   {
@@ -126,14 +61,6 @@ function TextExerciseGroupTypeEditor(
   const i18n = useI18n()
   const isCohesive = cohesive.value ?? false
 
-  const virtualParent = React.useRef(null)
-
-  const virtualizer = useVirtualResizeObserver({
-    size: children.length,
-    parentRef: virtualParent,
-    estimateSize: React.useCallback(() => 35, []),
-  })
-
   const contentRendered = content.render({
     renderSettings(children) {
       return (
@@ -159,51 +86,20 @@ function TextExerciseGroupTypeEditor(
           {contentRendered}
         </SemanticSection>
       </section>
-      <div
-        ref={virtualParent}
-        style={{
-          height: '100%',
-          overflow: 'auto',
-        }}
-      >
-        <div
-          style={{
-            height: `${virtualizer.totalSize}px`,
-            width: '100%',
-            position: 'relative',
-          }}
-        >
-          {virtualizer.virtualItems.map((virtualRow) => {
-            const child = children[virtualRow.index]
-            return (
-              <div
-                key={virtualRow.index}
-                ref={virtualRow.measureRef}
-                style={{
-                  position: 'absolute',
-                  top: 0,
-                  left: 0,
-                  width: '100%',
-                  transform: `translateY(${virtualRow.start}px)`,
-                }}
-              >
-                <section className="row" key={child.id}>
-                  <div className="col-sm-1 hidden-xs">
-                    <em>{getExerciseIndex(virtualRow.index)})</em>
-                  </div>
-                  <div className="col-sm-11 col-xs-12">
-                    <OptionalChild
-                      state={child}
-                      removeLabel={i18n.t('textExerciseGroup::Remove exercise')}
-                      onRemove={() => children.remove(virtualRow.index)}
-                    />
-                  </div>
-                </section>
-              </div>
-            )
-          })}
-        </div>
-      </div>
+      {children.map((child, index) => (
+        <section className="row" key={child.id}>
+          <div className="col-sm-1 hidden-xs">
+            <em>{getExerciseIndex(index)})</em>
+          </div>
+          <div className="col-sm-11 col-xs-12">
+            <OptionalChild
+              state={child}
+              removeLabel={i18n.t('textExerciseGroup::Remove exercise')}
+              onRemove={() => children.remove(index)}
+            />
+          </div>
+        </section>
+      ))}
       <AddButton onClick={() => children.insert()}>
         {i18n.t('textExerciseGroup::Add exercise')}
       </AddButton>

--- a/packages/private/edtr-io/src/plugins/types/text-solution.tsx
+++ b/packages/private/edtr-io/src/plugins/types/text-solution.tsx
@@ -82,7 +82,13 @@ function TextSolutionTypeEditor(props: TextSolutionTypeProps) {
         />
       )}
       <ThemeProvider theme={solutionTheme}>
-        <ExpandableBox renderTitle={renderTitle} editable={props.editable}>
+        <ExpandableBox
+          renderTitle={renderTitle}
+          editable={
+            /* Title is not editable. Also rendering collapsed */
+            false
+          }
+        >
           {props.state.content.render()}
         </ExpandableBox>
       </ThemeProvider>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2992,11 +2992,6 @@
     mem "^8.0.0"
     php-parser glayzzle/php-parser#4c5b0675f52c0baab2e5b10a4e50e5d7a79b2767
 
-"@reach/observe-rect@^1.1.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@reach/observe-rect/-/observe-rect-1.2.0.tgz#d7a6013b8aafcc64c778a0ccb83355a11204d3b2"
-  integrity sha512-Ba7HmkFgfQxZqqaeIWWkNK0rEhpxVQHIoVyW1YDSkGsGIXzcaW4deC8B0pZrNSSyLTdIk7y+5olKt5+g0GmFIQ==
-
 "@reach/router@^1.3.4":
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/@reach/router/-/router-1.3.4.tgz#d2574b19370a70c80480ed91f3da840136d10f8c"
@@ -15826,13 +15821,6 @@ react-transition-group@^4.3.0:
     dom-helpers "^5.0.1"
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
-
-react-virtual@^2.0.0:
-  version "2.8.2"
-  resolved "https://registry.yarnpkg.com/react-virtual/-/react-virtual-2.8.2.tgz#e204b30c57c426bd260ed1ac49f8b1099e92b7cb"
-  integrity sha512-CwnvF/3Jev4M14S9S7fgzGc0UFQ/bG/VXbrUCq+AB0zH8WGnVDTG0lQT7O3jPY76YLPzTHBu+AMl64Stp8+exg==
-  dependencies:
-    "@reach/observe-rect" "^1.1.0"
 
 react@^17.0.0:
   version "17.0.2"


### PR DESCRIPTION
Legacy port of Frontend PR: https://github.com/serlo/frontend/pull/1359

Our implementation of react-virtual currently isn't working (All elements are rendered anyway) and causing some UI issues (Not listening to dimension changes by spoilers, misplacing the plugin overlay). Easiest solution for now is to just revert #656 which this PR does.

Long-term we might want to wait for https://github.com/tannerlinsley/react-virtual/pull/80 or implement one of the solutions mentioned there.